### PR TITLE
Add source drift checks and debugging diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The pipeline validates upstream sources, fetches raw source data, normalizes can
 - [`calendars/`](calendars/): published subscriber-facing `.ics` files and calendar index
 - [`data/catalog/accepted/`](data/catalog/accepted/): accepted catalog records that feed calendar builds
 - [`data/catalog/reports/`](data/catalog/reports/): validation, reconciliation, and build reports
+- [`data/diagnostics/`](data/diagnostics/): source-boundary validation, fetch, and normalize diagnostics
 - [`config/calendars/`](config/calendars/): calendar manifest definitions
 - [`src/astrocal/`](src/astrocal/): Python runtime and adapters
 

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -378,8 +378,10 @@ Rule:
 - Live source checks are runtime validation commands, not normal automated tests.
 - The implementation must preserve enough diagnostics for future debug-skill work:
   - validation report
+  - validation summary
   - raw snapshot
-  - parse summary
+  - fetch summary
+  - normalize summary
   - normalized candidate output
   - reconciliation report
   - failure reason

--- a/specs/normalized-event-schema.md
+++ b/specs/normalized-event-schema.md
@@ -30,7 +30,14 @@ this schema and does not depend on source-specific payload structure.
     "status": "passed",
     "validated_at": "2026-03-01T12:00:00Z",
     "reason": null,
-    "checks": ["reachable", "required timing fields present", "detail url resolved"],
+    "checks": [
+      "reachable",
+      "canary payload present",
+      "canary required fields present",
+      "required timing fields present",
+      "detail url resolved"
+    ],
+    "canary_ok": true,
     "detail_url_ok": true
   },
   "content_hash": "sha256:...",
@@ -92,6 +99,8 @@ this schema and does not depend on source-specific payload structure.
 
 - `source_validation`
   - Required. Result of preflight validation for the source used in this run.
+  - `canary_ok` records whether the source-specific structure check passed before fetch or
+    normalization proceeded.
 
 - `content_hash`
   - Required. Hash of the normalized candidate content used for change detection.

--- a/specs/source-policy.md
+++ b/specs/source-policy.md
@@ -38,6 +38,28 @@ If any required validation fails:
 Validation artifacts should persist whether the canary checks passed via a dedicated
 boolean such as `canary_ok`, in addition to the human-readable validation `checks` list.
 
+## Diagnostic Artifacts
+
+Source-boundary runs should leave durable JSON artifacts that make debugging possible
+without rerunning the live source:
+
+- validation report under `data/catalog/reports/...`
+- validation summary under `data/diagnostics/.../validate-summary.json`
+- raw source snapshot under `data/raw/...`
+- fetch summary or failure under `data/diagnostics/.../fetch-summary.json` or
+  `data/diagnostics/.../fetch-failure.json`
+- normalize summary or failure under `data/diagnostics/.../normalize-summary.json` or
+  `data/diagnostics/.../normalize-failure.json`
+
+These artifacts should be sufficient to show:
+
+- which adapter ran
+- which upstream URL was used
+- whether the canary check passed
+- where the raw payload was stored
+- what the parser claims it extracted
+- where the failure occurred when the pipeline stopped
+
 ## Preferred Sources
 
 ### Moon phases

--- a/specs/source-policy.md
+++ b/specs/source-policy.md
@@ -35,6 +35,9 @@ If any required validation fails:
 - stop the action before normalization
 - in automation contexts, open an issue instead of continuing
 
+Validation artifacts should persist whether the canary checks passed via a dedicated
+boolean such as `canary_ok`, in addition to the human-readable validation `checks` list.
+
 ## Preferred Sources
 
 ### Moon phases

--- a/src/astrocal/adapters/astronomy/canary_checks.py
+++ b/src/astrocal/adapters/astronomy/canary_checks.py
@@ -1,0 +1,18 @@
+"""Small reusable canary checks for astronomy source validation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+
+def required_fields(sample: Mapping[str, object], fields: Iterable[str]) -> str | None:
+    missing = sorted(set(fields) - set(sample))
+    if missing:
+        return f"missing required fields: {', '.join(missing)}"
+    return None
+
+
+def non_empty_records(records: list[object], label: str) -> str | None:
+    if records:
+        return None
+    return f"{label} missing"

--- a/src/astrocal/adapters/astronomy/timeanddate_eclipses.py
+++ b/src/astrocal/adapters/astronomy/timeanddate_eclipses.py
@@ -87,6 +87,7 @@ class EclipsesAdapter:
                 "required timing fields present",
                 "detail url resolved",
             ],
+            canary_ok=True,
             detail_url_ok=True,
             source_url=self.source_url,
         )
@@ -193,6 +194,7 @@ class EclipsesAdapter:
             validated_at=self._now_provider(),
             checks=["reachable"],
             reason=reason,
+            canary_ok=False,
             detail_url_ok=False,
             source_url=self.source_url,
         )

--- a/src/astrocal/adapters/astronomy/timeanddate_eclipses.py
+++ b/src/astrocal/adapters/astronomy/timeanddate_eclipses.py
@@ -64,12 +64,13 @@ class EclipsesAdapter:
             if not urls:
                 return self._failed_report(year, "no configured eclipse detail URLs")
 
-            html = self._http_client.get(urls[0], timeout=30).text
-            parsed = _parse_eclipse_html(html, urls[0])
-            if not parsed["group_id"]:
-                return self._failed_report(year, "unable to derive eclipse identity")
-            if not parsed["full_duration"]:
-                return self._failed_report(year, "required timing fields missing")
+            for url in urls:
+                html = self._http_client.get(url, timeout=30).text
+                parsed = _parse_eclipse_html(html, url)
+                if not parsed["group_id"]:
+                    return self._failed_report(year, f"unable to derive eclipse identity: {url}")
+                if not parsed["full_duration"]:
+                    return self._failed_report(year, f"required timing fields missing: {url}")
         except Exception as exc:  # pragma: no cover
             return self._failed_report(year, str(exc))
 
@@ -81,6 +82,7 @@ class EclipsesAdapter:
             checks=[
                 "reachable",
                 "canary detail page reachable",
+                "canary all configured detail pages parse",
                 "canary timeline present",
                 "required timing fields present",
                 "detail url resolved",

--- a/src/astrocal/adapters/astronomy/timeanddate_eclipses.py
+++ b/src/astrocal/adapters/astronomy/timeanddate_eclipses.py
@@ -80,6 +80,8 @@ class EclipsesAdapter:
             validated_at=self._now_provider(),
             checks=[
                 "reachable",
+                "canary detail page reachable",
+                "canary timeline present",
                 "required timing fields present",
                 "detail url resolved",
             ],

--- a/src/astrocal/adapters/astronomy/usno_moon_phases.py
+++ b/src/astrocal/adapters/astronomy/usno_moon_phases.py
@@ -101,6 +101,7 @@ class MoonPhasesAdapter:
                 "required timing fields present",
                 "detail url resolved",
             ],
+            canary_ok=True,
             detail_url_ok=True,
             source_url=self.source_url,
         )
@@ -202,6 +203,7 @@ class MoonPhasesAdapter:
             validated_at=self._now_provider(),
             checks=["reachable"],
             reason=reason,
+            canary_ok=False,
             detail_url_ok=False,
             source_url=self.source_url,
         )

--- a/src/astrocal/adapters/astronomy/usno_moon_phases.py
+++ b/src/astrocal/adapters/astronomy/usno_moon_phases.py
@@ -9,6 +9,7 @@ from typing import Any, Protocol
 
 import requests
 
+from .canary_checks import non_empty_records, required_fields
 from ...hashing import sha256_text
 from ...models import (
     CandidateRecord,
@@ -74,14 +75,14 @@ class MoonPhasesAdapter:
             response.raise_for_status()
             payload = response.json()
             phases = payload.get("phasedata", [])
-            if not phases:
-                return self._failed_report(year, "phasedata missing")
+            canary_failure = non_empty_records(phases, "phasedata")
+            if canary_failure:
+                return self._failed_report(year, canary_failure)
 
             sample = phases[0]
-            required_fields = {"phase", "year", "month", "day", "time"}
-            missing = sorted(required_fields - set(sample))
-            if missing:
-                return self._failed_report(year, f"missing required fields: {', '.join(missing)}")
+            canary_failure = required_fields(sample, {"phase", "year", "month", "day", "time"})
+            if canary_failure:
+                return self._failed_report(year, canary_failure)
 
             if not _detail_url_for_phase(sample["phase"], sample["year"], sample["month"], sample["day"]):
                 return self._failed_report(year, "detail URL derivation failed")
@@ -95,6 +96,8 @@ class MoonPhasesAdapter:
             validated_at=self._now_provider(),
             checks=[
                 "reachable",
+                "canary payload present",
+                "canary required fields present",
                 "required timing fields present",
                 "detail url resolved",
             ],

--- a/src/astrocal/adapters/astronomy/usno_seasons.py
+++ b/src/astrocal/adapters/astronomy/usno_seasons.py
@@ -164,6 +164,7 @@ class SeasonsAdapter:
                 "required timing fields present",
                 "detail url resolved",
             ],
+            canary_ok=True,
             detail_url_ok=True,
             source_url=self.source_url,
         )
@@ -270,6 +271,7 @@ class SeasonsAdapter:
             validated_at=self._now_provider(),
             checks=["reachable"],
             reason=reason,
+            canary_ok=False,
             detail_url_ok=False,
             source_url=self.source_url,
         )

--- a/src/astrocal/adapters/astronomy/usno_seasons.py
+++ b/src/astrocal/adapters/astronomy/usno_seasons.py
@@ -8,6 +8,7 @@ from typing import Any, Protocol
 
 import requests
 
+from .canary_checks import non_empty_records, required_fields
 from ...hashing import sha256_text
 from ...models import (
     CandidateRecord,
@@ -132,17 +133,14 @@ class SeasonsAdapter:
             response.raise_for_status()
             payload = response.json()
             data = _season_records(payload.get("data", []))
-            if not data:
-                return self._failed_report(year, "season-marker data missing")
+            canary_failure = non_empty_records(data, "season-marker data")
+            if canary_failure:
+                return self._failed_report(year, canary_failure)
 
             sample = data[0]
-            required_fields = {"phenom", "year", "month", "day", "time"}
-            missing = sorted(required_fields - set(sample))
-            if missing:
-                return self._failed_report(
-                    year,
-                    f"missing required fields: {', '.join(missing)}",
-                )
+            canary_failure = required_fields(sample, {"phenom", "year", "month", "day", "time"})
+            if canary_failure:
+                return self._failed_report(year, canary_failure)
 
             if not _detail_url_for_season(
                 sample["phenom"],
@@ -161,6 +159,8 @@ class SeasonsAdapter:
             validated_at=self._now_provider(),
             checks=[
                 "reachable",
+                "canary payload present",
+                "canary required fields present",
                 "required timing fields present",
                 "detail url resolved",
             ],

--- a/src/astrocal/models/candidate.py
+++ b/src/astrocal/models/candidate.py
@@ -12,6 +12,7 @@ class ValidationResult:
     validated_at: str
     reason: str | None
     checks: list[str] = field(default_factory=list)
+    canary_ok: bool = True
     detail_url_ok: bool = True
 
 

--- a/src/astrocal/models/reports.py
+++ b/src/astrocal/models/reports.py
@@ -14,6 +14,7 @@ class ValidationReport:
     validated_at: str
     checks: list[str] = field(default_factory=list)
     reason: str | None = None
+    canary_ok: bool = True
     detail_url_ok: bool = True
     source_url: str | None = None
 

--- a/src/astrocal/repositories/__init__.py
+++ b/src/astrocal/repositories/__init__.py
@@ -2,8 +2,9 @@
 
 from .candidate_store import CandidateStore
 from .catalog_store import CatalogStore
+from .diagnostic_store import DiagnosticStore
 from .raw_store import RawStore
 from .report_store import ReportStore
 from .sequence_store import SequenceStore
 
-__all__ = ["CandidateStore", "CatalogStore", "RawStore", "ReportStore", "SequenceStore"]
+__all__ = ["CandidateStore", "CatalogStore", "DiagnosticStore", "RawStore", "ReportStore", "SequenceStore"]

--- a/src/astrocal/repositories/diagnostic_store.py
+++ b/src/astrocal/repositories/diagnostic_store.py
@@ -1,0 +1,29 @@
+"""Persistence for source-boundary diagnostic artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..jsonio import write_json
+from ..paths import PROJECT_ROOT
+
+
+class DiagnosticStore:
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base_dir = base_dir or PROJECT_ROOT / "data" / "diagnostics"
+
+    def path_for(self, source_type: str, year: int, source_name: str, filename: str) -> Path:
+        return self._base_dir / source_type / str(year) / source_name / filename
+
+    def write_json(
+        self,
+        source_type: str,
+        year: int,
+        source_name: str,
+        filename: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        path = self.path_for(source_type, year, source_name, filename)
+        write_json(path, payload)
+        return path

--- a/src/astrocal/services/fetch_service.py
+++ b/src/astrocal/services/fetch_service.py
@@ -5,16 +5,58 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ..models import RawFetchResult, ValidationReport
+from ..repositories import DiagnosticStore
 
 
 def fetch_source_family(
     year: int,
     adapters: Mapping[str, object],
     validation_reports: list[ValidationReport],
+    diagnostic_store: DiagnosticStore | None = None,
 ) -> list[RawFetchResult]:
     failed_reports = [report for report in validation_reports if report.status != "passed"]
     if failed_reports:
         reasons = ", ".join(report.source_name for report in failed_reports)
         raise RuntimeError(f"Refusing to fetch after validation failure: {reasons}")
 
-    return [adapter.fetch(year) for adapter in adapters.values()]
+    diagnostic_store = diagnostic_store or DiagnosticStore()
+    results: list[RawFetchResult] = []
+    for adapter in adapters.values():
+        try:
+            result = adapter.fetch(year)
+        except Exception as exc:
+            diagnostic_store.write_json(
+                getattr(adapter, "source_type", ""),
+                year,
+                getattr(adapter, "source_name", ""),
+                "fetch-failure.json",
+                {
+                    "source_name": getattr(adapter, "source_name", ""),
+                    "source_type": getattr(adapter, "source_type", ""),
+                    "year": year,
+                    "source_adapter": getattr(adapter, "source_adapter", ""),
+                    "source_url": getattr(adapter, "source_url", ""),
+                    "failure_stage": "fetch",
+                    "reason": str(exc),
+                },
+            )
+            raise
+        diagnostic_store.write_json(
+            getattr(adapter, "source_type", ""),
+            year,
+            result.source_name,
+            "fetch-summary.json",
+            {
+                "source_name": result.source_name,
+                "source_type": getattr(adapter, "source_type", ""),
+                "year": year,
+                "source_adapter": getattr(adapter, "source_adapter", ""),
+                "source_url": result.source_url,
+                "raw_ref": result.raw_ref,
+                "fetched_at": result.fetched_at,
+                "metadata": result.metadata,
+            },
+        )
+        results.append(result)
+
+    return results

--- a/src/astrocal/services/normalize_service.py
+++ b/src/astrocal/services/normalize_service.py
@@ -78,6 +78,12 @@ def _normalize_summary(
 ) -> dict[str, object]:
     event_types = sorted({candidate.event_type for candidate in candidates})
     variants = sorted({candidate.variant for candidate in candidates})
+    titles_sample = [candidate.title for candidate in candidates[:5]]
+    metadata_keys = sorted({key for candidate in candidates for key in candidate.metadata})
+    canary_ok = all(
+        candidate.source_validation is None or candidate.source_validation.status == "passed"
+        for candidate in candidates
+    )
     return {
         "source_name": source_name,
         "source_type": source_type,
@@ -88,6 +94,9 @@ def _normalize_summary(
         "candidate_count": len(candidates),
         "event_types": event_types,
         "variants": variants,
+        "titles_sample": titles_sample,
         "occurrence_ids_sample": [candidate.occurrence_id for candidate in candidates[:5]],
         "detail_url_count": sum(1 for candidate in candidates if candidate.detail_url),
+        "metadata_keys": metadata_keys,
+        "canary_ok": canary_ok,
     }

--- a/src/astrocal/services/normalize_service.py
+++ b/src/astrocal/services/normalize_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from ..models import CandidateRecord, RawFetchResult
-from ..repositories import CandidateStore
+from ..repositories import CandidateStore, DiagnosticStore
 
 
 def normalize_source_family(
@@ -14,17 +14,80 @@ def normalize_source_family(
     adapters: Mapping[str, object],
     raw_results: list[RawFetchResult],
     candidate_store: CandidateStore | None = None,
+    diagnostic_store: DiagnosticStore | None = None,
 ) -> list[tuple[str, list[CandidateRecord]]]:
     if source_family != "astronomy":
         raise ValueError(f"Unsupported source family: {source_family}")
 
     candidate_store = candidate_store or CandidateStore()
+    diagnostic_store = diagnostic_store or DiagnosticStore()
     raw_results_by_name = {result.source_name: result for result in raw_results}
 
     normalized_results: list[tuple[str, list[CandidateRecord]]] = []
     for name, adapter in adapters.items():
         raw_result = raw_results_by_name[name]
-        candidates = adapter.normalize(year, raw_result)
+        try:
+            candidates = adapter.normalize(year, raw_result)
+        except Exception as exc:
+            diagnostic_store.write_json(
+                source_family,
+                year,
+                name,
+                "normalize-failure.json",
+                {
+                    "source_name": name,
+                    "source_type": source_family,
+                    "year": year,
+                    "source_adapter": getattr(adapter, "source_adapter", ""),
+                    "source_url": getattr(adapter, "source_url", ""),
+                    "raw_ref": raw_result.raw_ref,
+                    "failure_stage": "normalize",
+                    "reason": str(exc),
+                },
+            )
+            raise
         candidate_store.save(source_family, year, name, candidates)
+        diagnostic_store.write_json(
+            source_family,
+            year,
+            name,
+            "normalize-summary.json",
+            _normalize_summary(
+                source_type=source_family,
+                year=year,
+                source_name=name,
+                source_adapter=getattr(adapter, "source_adapter", ""),
+                source_url=getattr(adapter, "source_url", ""),
+                raw_ref=raw_result.raw_ref,
+                candidates=candidates,
+            ),
+        )
         normalized_results.append((name, candidates))
     return normalized_results
+
+
+def _normalize_summary(
+    *,
+    source_type: str,
+    year: int,
+    source_name: str,
+    source_adapter: str,
+    source_url: str,
+    raw_ref: str,
+    candidates: list[CandidateRecord],
+) -> dict[str, object]:
+    event_types = sorted({candidate.event_type for candidate in candidates})
+    variants = sorted({candidate.variant for candidate in candidates})
+    return {
+        "source_name": source_name,
+        "source_type": source_type,
+        "year": year,
+        "source_adapter": source_adapter,
+        "source_url": source_url,
+        "raw_ref": raw_ref,
+        "candidate_count": len(candidates),
+        "event_types": event_types,
+        "variants": variants,
+        "occurrence_ids_sample": [candidate.occurrence_id for candidate in candidates[:5]],
+        "detail_url_count": sum(1 for candidate in candidates if candidate.detail_url),
+    }

--- a/src/astrocal/services/normalize_service.py
+++ b/src/astrocal/services/normalize_service.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
+from pathlib import Path
 
 from ..models import CandidateRecord, RawFetchResult
+from ..paths import PROJECT_ROOT
 from ..repositories import CandidateStore, DiagnosticStore
 
 
@@ -99,4 +102,59 @@ def _normalize_summary(
         "detail_url_count": sum(1 for candidate in candidates if candidate.detail_url),
         "metadata_keys": metadata_keys,
         "canary_ok": canary_ok,
+        "extraction_summary": _extraction_summary(
+            source_name=source_name,
+            raw_ref=raw_ref,
+            candidates=candidates,
+        ),
     }
+
+
+def _extraction_summary(
+    *,
+    source_name: str,
+    raw_ref: str,
+    candidates: list[CandidateRecord],
+) -> dict[str, object]:
+    if source_name == "moon-phases":
+        return {
+            "phase_names": sorted({candidate.metadata.get("phase", "") for candidate in candidates if candidate.metadata.get("phase")}),
+            "first_start": min((candidate.start for candidate in candidates), default=""),
+            "last_start": max((candidate.start for candidate in candidates), default=""),
+        }
+    if source_name == "seasons":
+        return {
+            "titles_seen": sorted({candidate.title for candidate in candidates}),
+            "ignored_non_season_row_count": _ignored_non_season_row_count(raw_ref),
+        }
+    if source_name == "eclipses":
+        variant_counts: dict[str, int] = {}
+        detail_urls_sample: list[str] = []
+        for candidate in candidates:
+            variant_counts[candidate.variant] = variant_counts.get(candidate.variant, 0) + 1
+            if candidate.detail_url and candidate.detail_url not in detail_urls_sample:
+                detail_urls_sample.append(candidate.detail_url)
+        return {
+            "titles_seen": sorted({candidate.title for candidate in candidates}),
+            "variant_counts": variant_counts,
+            "detail_urls_sample": detail_urls_sample[:3],
+        }
+    return {}
+
+
+def _ignored_non_season_row_count(raw_ref: str) -> int:
+    if not raw_ref:
+        return 0
+    raw_path = Path(raw_ref)
+    if not raw_path.is_absolute():
+        raw_path = PROJECT_ROOT / raw_ref
+    if not raw_path.exists():
+        return 0
+    payload = json.loads(raw_path.read_text(encoding="utf-8"))
+    rows = payload.get("data", [])
+    season_rows = [
+        row
+        for row in rows
+        if str(row.get("phenom", "")).strip().lower() in {"equinox", "solstice"}
+    ]
+    return max(len(rows) - len(season_rows), 0)

--- a/src/astrocal/services/normalize_service.py
+++ b/src/astrocal/services/normalize_service.py
@@ -31,6 +31,23 @@ def normalize_source_family(
         raw_result = raw_results_by_name[name]
         try:
             candidates = adapter.normalize(year, raw_result)
+            summary = _normalize_summary(
+                source_type=source_family,
+                year=year,
+                source_name=name,
+                source_adapter=getattr(adapter, "source_adapter", ""),
+                source_url=getattr(adapter, "source_url", ""),
+                raw_ref=raw_result.raw_ref,
+                candidates=candidates,
+            )
+            diagnostic_store.write_json(
+                source_family,
+                year,
+                name,
+                "normalize-summary.json",
+                summary,
+            )
+            candidate_store.save(source_family, year, name, candidates)
         except Exception as exc:
             diagnostic_store.write_json(
                 source_family,
@@ -49,22 +66,6 @@ def normalize_source_family(
                 },
             )
             raise
-        candidate_store.save(source_family, year, name, candidates)
-        diagnostic_store.write_json(
-            source_family,
-            year,
-            name,
-            "normalize-summary.json",
-            _normalize_summary(
-                source_type=source_family,
-                year=year,
-                source_name=name,
-                source_adapter=getattr(adapter, "source_adapter", ""),
-                source_url=getattr(adapter, "source_url", ""),
-                raw_ref=raw_result.raw_ref,
-                candidates=candidates,
-            ),
-        )
         normalized_results.append((name, candidates))
     return normalized_results
 

--- a/src/astrocal/services/validation_service.py
+++ b/src/astrocal/services/validation_service.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 
 from ..models import ValidationReport
-from ..repositories import ReportStore
+from ..repositories import DiagnosticStore, ReportStore
 
 
 def validate_source_family(
@@ -14,6 +14,7 @@ def validate_source_family(
     year: int,
     adapters: Mapping[str, object],
     report_store: ReportStore | None = None,
+    diagnostic_store: DiagnosticStore | None = None,
     run_timestamp: str | None = None,
 ) -> tuple[int, list[ValidationReport]]:
     if source_family != "astronomy":
@@ -25,10 +26,29 @@ def validate_source_family(
         reports.append(report)
 
     report_store = report_store or ReportStore()
+    diagnostic_store = diagnostic_store or DiagnosticStore()
     run_timestamp = run_timestamp or _run_timestamp()
     for report in reports:
         report_name = f"validate.{report.source_name}.{year}"
         report_store.write_json_report(run_timestamp, report_name, report.to_dict())
+        diagnostic_store.write_json(
+            source_family,
+            year,
+            report.source_name,
+            "validate-summary.json",
+            {
+                "source_name": report.source_name,
+                "source_type": source_family,
+                "year": year,
+                "status": report.status,
+                "validated_at": report.validated_at,
+                "reason": report.reason,
+                "canary_ok": report.canary_ok,
+                "detail_url_ok": report.detail_url_ok,
+                "checks": report.checks,
+                "source_url": report.source_url,
+            },
+        )
 
     exit_code = 0 if all(report.status == "passed" for report in reports) else 1
     return exit_code, reports

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ class CliAdapter:
             status="passed",
             validated_at="2026-03-01T00:00:00Z",
             checks=["reachable"],
+            canary_ok=True,
             source_url="https://example.com/moon-phases",
         )
 

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -6,7 +6,7 @@ from astrocal.models import (
     SourceReference,
     ValidationResult,
 )
-from astrocal.repositories import CandidateStore, CatalogStore, SequenceStore
+from astrocal.repositories import CandidateStore, CatalogStore, DiagnosticStore, SequenceStore
 
 
 def build_candidate() -> CandidateRecord:
@@ -97,3 +97,18 @@ def test_sequence_store_round_trip(tmp_path) -> None:
 
     assert saved_path.exists()
     assert loaded == {"event-1": 2, "event-2": 1}
+
+
+def test_diagnostic_store_round_trip(tmp_path) -> None:
+    store = DiagnosticStore(base_dir=tmp_path)
+
+    saved_path = store.write_json(
+        "astronomy",
+        2026,
+        "moon-phases",
+        "normalize-summary.json",
+        {"candidate_count": 2, "source_name": "moon-phases"},
+    )
+
+    assert saved_path.exists()
+    assert saved_path.read_text(encoding="utf-8").startswith("{")

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -34,6 +34,7 @@ def build_candidate() -> CandidateRecord:
             validated_at="2026-03-01T00:00:00Z",
             reason=None,
             checks=["reachable"],
+            canary_ok=True,
             detail_url_ok=True,
         ),
         content_hash="sha256:abc123",
@@ -63,6 +64,7 @@ def test_candidate_store_round_trip(tmp_path) -> None:
     assert loaded[0].occurrence_id == candidate.occurrence_id
     assert loaded[0].source_validation is not None
     assert loaded[0].source_validation.status == "passed"
+    assert loaded[0].source_validation.canary_ok is True
 
 
 def test_catalog_store_round_trip(tmp_path) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,6 +21,7 @@ class PassingAdapter:
             status="passed",
             validated_at="2026-03-01T00:00:00Z",
             checks=["reachable", "fields present"],
+            canary_ok=True,
             source_url="https://example.com/moon-phases",
         )
 
@@ -48,6 +49,7 @@ class FailingAdapter(PassingAdapter):
             validated_at="2026-03-01T00:00:00Z",
             checks=["reachable"],
             reason="required timing fields missing",
+            canary_ok=False,
             source_url="https://example.com/eclipses",
         )
 
@@ -67,6 +69,7 @@ def test_validate_source_family_writes_json_reports(tmp_path) -> None:
     assert exit_code == 0
     assert len(reports) == 1
     assert json_report.exists()
+    assert reports[0].canary_ok is True
 
 
 def test_validate_source_family_returns_non_zero_for_failed_validation(tmp_path) -> None:
@@ -80,6 +83,7 @@ def test_validate_source_family_returns_non_zero_for_failed_validation(tmp_path)
 
     assert exit_code == 1
     assert reports[0].status == "failed"
+    assert reports[0].canary_ok is False
 
 
 def test_fetch_source_family_stops_after_validation_failure() -> None:
@@ -95,6 +99,7 @@ def test_fetch_source_family_stops_after_validation_failure() -> None:
                     validated_at="2026-03-01T00:00:00Z",
                     checks=["reachable"],
                     reason="required timing fields missing",
+                    canary_ok=False,
                     source_url="https://example.com/eclipses",
                 )
             ],
@@ -112,6 +117,7 @@ def test_fetch_source_family_returns_raw_results_after_validation_passes() -> No
                 status="passed",
                 validated_at="2026-03-01T00:00:00Z",
                 checks=["reachable"],
+                canary_ok=True,
                 source_url="https://example.com/moon-phases",
             )
         ],

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -62,20 +62,27 @@ class BrokenNormalizeAdapter(PassingAdapter):
 
 def test_validate_source_family_writes_json_reports(tmp_path) -> None:
     report_store = ReportStore(base_dir=tmp_path)
+    diagnostic_store = DiagnosticStore(base_dir=tmp_path / "diagnostics")
 
     exit_code, reports = validate_source_family(
         "astronomy",
         2026,
         adapters={"moon-phases": PassingAdapter()},
         report_store=report_store,
+        diagnostic_store=diagnostic_store,
         run_timestamp="2026-03-01T12-00-00Z",
     )
 
     json_report = tmp_path / "2026-03-01T12-00-00Z" / "validate.moon-phases.2026.json"
+    diagnostic_summary = (
+        tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "validate-summary.json"
+    )
     assert exit_code == 0
     assert len(reports) == 1
     assert json_report.exists()
+    assert diagnostic_summary.exists()
     assert reports[0].canary_ok is True
+    assert '"canary_ok": true' in diagnostic_summary.read_text(encoding="utf-8")
 
 
 def test_validate_source_family_returns_non_zero_for_failed_validation(tmp_path) -> None:
@@ -84,12 +91,18 @@ def test_validate_source_family_returns_non_zero_for_failed_validation(tmp_path)
         2026,
         adapters={"eclipses": FailingAdapter()},
         report_store=ReportStore(base_dir=tmp_path),
+        diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
         run_timestamp="2026-03-01T12-00-00Z",
     )
 
+    diagnostic_summary = (
+        tmp_path / "diagnostics" / "astronomy" / "2026" / "eclipses" / "validate-summary.json"
+    )
     assert exit_code == 1
     assert reports[0].status == "failed"
     assert reports[0].canary_ok is False
+    assert diagnostic_summary.exists()
+    assert '"reason": "required timing fields missing"' in diagnostic_summary.read_text(encoding="utf-8")
 
 
 def test_fetch_source_family_stops_after_validation_failure() -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -153,7 +153,11 @@ def test_normalize_source_family_writes_summary_diagnostics(tmp_path) -> None:
     summary_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "normalize-summary.json"
     assert len(results) == 1
     assert summary_path.exists()
-    assert '"candidate_count": 0' in summary_path.read_text(encoding="utf-8")
+    summary_text = summary_path.read_text(encoding="utf-8")
+    assert '"candidate_count": 0' in summary_text
+    assert '"canary_ok": true' in summary_text
+    assert '"metadata_keys": []' in summary_text
+    assert '"titles_sample": []' in summary_text
 
 
 def test_normalize_source_family_writes_failure_diagnostics(tmp_path) -> None:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import pytest
 
 from astrocal.models import RawFetchResult, ValidationReport
-from astrocal.repositories import ReportStore
+from astrocal.repositories import DiagnosticStore, ReportStore
 from astrocal.services.fetch_service import fetch_source_family
+from astrocal.services.normalize_service import normalize_source_family
 from astrocal.services.validation_service import validate_source_family
 
 
@@ -52,6 +53,11 @@ class FailingAdapter(PassingAdapter):
             canary_ok=False,
             source_url="https://example.com/eclipses",
         )
+
+
+class BrokenNormalizeAdapter(PassingAdapter):
+    def normalize(self, year: int, raw_result: RawFetchResult) -> list[object]:
+        raise ValueError("unexpected payload shape")
 
 
 def test_validate_source_family_writes_json_reports(tmp_path) -> None:
@@ -125,3 +131,51 @@ def test_fetch_source_family_returns_raw_results_after_validation_passes() -> No
 
     assert len(results) == 1
     assert results[0].raw_ref.endswith("response.json")
+
+
+def test_normalize_source_family_writes_summary_diagnostics(tmp_path) -> None:
+    results = normalize_source_family(
+        "astronomy",
+        2026,
+        adapters={"moon-phases": PassingAdapter()},
+        raw_results=[
+            RawFetchResult(
+                source_name="moon-phases",
+                year=2026,
+                fetched_at="2026-03-01T00:01:00Z",
+                raw_ref="data/raw/astronomy/2026/moon-phases/response.json",
+                source_url="https://example.com/moon-phases",
+            )
+        ],
+        diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+    )
+
+    summary_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "normalize-summary.json"
+    assert len(results) == 1
+    assert summary_path.exists()
+    assert '"candidate_count": 0' in summary_path.read_text(encoding="utf-8")
+
+
+def test_normalize_source_family_writes_failure_diagnostics(tmp_path) -> None:
+    with pytest.raises(ValueError, match="unexpected payload shape"):
+        normalize_source_family(
+            "astronomy",
+            2026,
+            adapters={"moon-phases": BrokenNormalizeAdapter()},
+            raw_results=[
+                RawFetchResult(
+                    source_name="moon-phases",
+                    year=2026,
+                    fetched_at="2026-03-01T00:01:00Z",
+                    raw_ref="data/raw/astronomy/2026/moon-phases/response.json",
+                    source_url="https://example.com/moon-phases",
+                )
+            ],
+            diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+        )
+
+    failure_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "normalize-failure.json"
+    assert failure_path.exists()
+    failure_text = failure_path.read_text(encoding="utf-8")
+    assert '"failure_stage": "normalize"' in failure_text
+    assert '"reason": "unexpected payload shape"' in failure_text

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from astrocal.models import RawFetchResult, ValidationReport
-from astrocal.repositories import DiagnosticStore, ReportStore
+from astrocal.repositories import CandidateStore, DiagnosticStore, ReportStore
 from astrocal.services.fetch_service import fetch_source_family
 from astrocal.services.normalize_service import normalize_source_family
 from astrocal.services.validation_service import validate_source_family
@@ -63,6 +63,11 @@ class BrokenNormalizeAdapter(PassingAdapter):
 class BrokenFetchAdapter(PassingAdapter):
     def fetch(self, year: int) -> RawFetchResult:
         raise ValueError("request timed out")
+
+
+class BrokenCandidateStore(CandidateStore):
+    def save(self, source_type: str, year: int, source_name: str, candidates: list[object]):
+        raise OSError("unable to persist candidates")
 
 
 def test_validate_source_family_writes_json_reports(tmp_path) -> None:
@@ -252,3 +257,35 @@ def test_normalize_source_family_writes_failure_diagnostics(tmp_path) -> None:
     failure_text = failure_path.read_text(encoding="utf-8")
     assert '"failure_stage": "normalize"' in failure_text
     assert '"reason": "unexpected payload shape"' in failure_text
+
+
+def test_normalize_source_family_writes_failure_diagnostics_when_candidate_save_fails(
+    tmp_path,
+) -> None:
+    with pytest.raises(OSError, match="unable to persist candidates"):
+        normalize_source_family(
+            "astronomy",
+            2026,
+            adapters={"moon-phases": PassingAdapter()},
+            raw_results=[
+                RawFetchResult(
+                    source_name="moon-phases",
+                    year=2026,
+                    fetched_at="2026-03-01T00:01:00Z",
+                    raw_ref="data/raw/astronomy/2026/moon-phases/response.json",
+                    source_url="https://example.com/moon-phases",
+                )
+            ],
+            candidate_store=BrokenCandidateStore(base_dir=tmp_path / "normalized"),
+            diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+        )
+
+    summary_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "normalize-summary.json"
+    failure_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "normalize-failure.json"
+    candidate_path = tmp_path / "normalized" / "astronomy" / "2026" / "moon-phases.json"
+
+    assert summary_path.exists()
+    assert failure_path.exists()
+    assert not candidate_path.exists()
+    failure_text = failure_path.read_text(encoding="utf-8")
+    assert '"reason": "unable to persist candidates"' in failure_text

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -60,6 +60,11 @@ class BrokenNormalizeAdapter(PassingAdapter):
         raise ValueError("unexpected payload shape")
 
 
+class BrokenFetchAdapter(PassingAdapter):
+    def fetch(self, year: int) -> RawFetchResult:
+        raise ValueError("request timed out")
+
+
 def test_validate_source_family_writes_json_reports(tmp_path) -> None:
     report_store = ReportStore(base_dir=tmp_path)
     diagnostic_store = DiagnosticStore(base_dir=tmp_path / "diagnostics")
@@ -144,6 +149,57 @@ def test_fetch_source_family_returns_raw_results_after_validation_passes() -> No
 
     assert len(results) == 1
     assert results[0].raw_ref.endswith("response.json")
+
+
+def test_fetch_source_family_writes_fetch_summary_diagnostics(tmp_path) -> None:
+    results = fetch_source_family(
+        2026,
+        adapters={"moon-phases": PassingAdapter()},
+        validation_reports=[
+            ValidationReport(
+                source_name="moon-phases",
+                year=2026,
+                status="passed",
+                validated_at="2026-03-01T00:00:00Z",
+                checks=["reachable"],
+                canary_ok=True,
+                source_url="https://example.com/moon-phases",
+            )
+        ],
+        diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+    )
+
+    summary_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "fetch-summary.json"
+    assert len(results) == 1
+    assert summary_path.exists()
+    summary_text = summary_path.read_text(encoding="utf-8")
+    assert '"raw_ref": "data/raw/astronomy/2026/moon-phases/response.json"' in summary_text
+
+
+def test_fetch_source_family_writes_failure_diagnostics(tmp_path) -> None:
+    with pytest.raises(ValueError, match="request timed out"):
+        fetch_source_family(
+            2026,
+            adapters={"moon-phases": BrokenFetchAdapter()},
+            validation_reports=[
+                ValidationReport(
+                    source_name="moon-phases",
+                    year=2026,
+                    status="passed",
+                    validated_at="2026-03-01T00:00:00Z",
+                    checks=["reachable"],
+                    canary_ok=True,
+                    source_url="https://example.com/moon-phases",
+                )
+            ],
+            diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+        )
+
+    failure_path = tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "fetch-failure.json"
+    assert failure_path.exists()
+    failure_text = failure_path.read_text(encoding="utf-8")
+    assert '"failure_stage": "fetch"' in failure_text
+    assert '"reason": "request timed out"' in failure_text
 
 
 def test_normalize_source_family_writes_summary_diagnostics(tmp_path) -> None:

--- a/tests/test_timeanddate_eclipses.py
+++ b/tests/test_timeanddate_eclipses.py
@@ -124,3 +124,18 @@ def test_eclipse_titles_use_canonical_type_names(tmp_path: Path) -> None:
         titles_by_occurrence["astronomy/eclipse/2026-08-28/partial-moon/full-duration"]
         == "Partial Lunar Eclipse"
     )
+
+
+def test_validate_timeanddate_eclipses_fails_canary_when_timeline_is_missing(tmp_path: Path) -> None:
+    adapter = EclipsesAdapter(
+        http_client=FixtureHttpClient(
+            {"https://www.timeanddate.com/eclipse/lunar/2026-march-3": "<html><title>Example</title></html>"}
+        ),
+        raw_store=RawStore(base_dir=tmp_path / "raw"),
+        now_provider=lambda: "2026-03-01T12:00:00Z",
+    )
+
+    report = adapter.validate(2026)
+
+    assert report.status == "failed"
+    assert report.reason == "unable to derive eclipse identity"

--- a/tests/test_timeanddate_eclipses.py
+++ b/tests/test_timeanddate_eclipses.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from astrocal.adapters.astronomy.timeanddate_eclipses import EclipsesAdapter
-from astrocal.repositories import CandidateStore, RawStore
+from astrocal.repositories import CandidateStore, DiagnosticStore, RawStore
 from astrocal.services.normalize_service import normalize_source_family
 
 
@@ -125,6 +126,44 @@ def test_eclipse_titles_use_canonical_type_names(tmp_path: Path) -> None:
         titles_by_occurrence["astronomy/eclipse/2026-08-28/partial-moon/full-duration"]
         == "Partial Lunar Eclipse"
     )
+
+
+def test_normalize_diagnostics_include_eclipse_extraction_summary(tmp_path: Path) -> None:
+    adapter = build_adapter(tmp_path)
+
+    raw_result = adapter.fetch(2026)
+    normalize_source_family(
+        "astronomy",
+        2026,
+        adapters={"eclipses": adapter},
+        raw_results=[raw_result],
+        candidate_store=CandidateStore(base_dir=tmp_path / "normalized"),
+        diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+    )
+
+    summary_path = (
+        tmp_path / "diagnostics" / "astronomy" / "2026" / "eclipses" / "normalize-summary.json"
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert summary["extraction_summary"] == {
+        "titles_seen": [
+            "Partial Lunar Eclipse",
+            "Total Lunar Eclipse",
+            "Total Lunar Eclipse: Totality",
+            "Total Solar Eclipse",
+            "Total Solar Eclipse: Totality",
+        ],
+        "variant_counts": {
+            "full-duration": 3,
+            "totality": 2,
+        },
+        "detail_urls_sample": [
+            "https://www.timeanddate.com/eclipse/lunar/2026-march-3",
+            "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+            "https://www.timeanddate.com/eclipse/lunar/2026-august-28",
+        ],
+    }
 
 
 def test_validate_timeanddate_eclipses_fails_canary_when_timeline_is_missing(tmp_path: Path) -> None:

--- a/tests/test_timeanddate_eclipses.py
+++ b/tests/test_timeanddate_eclipses.py
@@ -129,7 +129,11 @@ def test_eclipse_titles_use_canonical_type_names(tmp_path: Path) -> None:
 def test_validate_timeanddate_eclipses_fails_canary_when_timeline_is_missing(tmp_path: Path) -> None:
     adapter = EclipsesAdapter(
         http_client=FixtureHttpClient(
-            {"https://www.timeanddate.com/eclipse/lunar/2026-march-3": "<html><title>Example</title></html>"}
+            {
+                "https://www.timeanddate.com/eclipse/lunar/2026-march-3": "<html><title>Example</title></html>",
+                "https://www.timeanddate.com/eclipse/solar/2026-august-12": "<html><title>Example</title></html>",
+                "https://www.timeanddate.com/eclipse/lunar/2026-august-28": "<html><title>Example</title></html>",
+            }
         ),
         raw_store=RawStore(base_dir=tmp_path / "raw"),
         now_provider=lambda: "2026-03-01T12:00:00Z",
@@ -138,4 +142,32 @@ def test_validate_timeanddate_eclipses_fails_canary_when_timeline_is_missing(tmp
     report = adapter.validate(2026)
 
     assert report.status == "failed"
-    assert report.reason == "unable to derive eclipse identity"
+    assert report.reason == (
+        "unable to derive eclipse identity: "
+        "https://www.timeanddate.com/eclipse/lunar/2026-march-3"
+    )
+
+
+def test_validate_timeanddate_eclipses_checks_all_configured_pages(tmp_path: Path) -> None:
+    pages = {
+        "https://www.timeanddate.com/eclipse/lunar/2026-march-3": (
+            FIXTURE_DIR / "eclipse-detail-lunar-2026-03-03.html"
+        ).read_text(encoding="utf-8"),
+        "https://www.timeanddate.com/eclipse/solar/2026-august-12": "<html><title>Broken</title></html>",
+        "https://www.timeanddate.com/eclipse/lunar/2026-august-28": (
+            FIXTURE_DIR / "eclipse-detail-lunar-2026-08-28.html"
+        ).read_text(encoding="utf-8"),
+    }
+    adapter = EclipsesAdapter(
+        http_client=FixtureHttpClient(pages),
+        raw_store=RawStore(base_dir=tmp_path / "raw"),
+        now_provider=lambda: "2026-03-01T12:00:00Z",
+    )
+
+    report = adapter.validate(2026)
+
+    assert report.status == "failed"
+    assert report.reason == (
+        "unable to derive eclipse identity: "
+        "https://www.timeanddate.com/eclipse/solar/2026-august-12"
+    )

--- a/tests/test_timeanddate_eclipses.py
+++ b/tests/test_timeanddate_eclipses.py
@@ -51,6 +51,7 @@ def test_validate_timeanddate_eclipses_fixture_passes(tmp_path: Path) -> None:
     report = adapter.validate(2026)
 
     assert report.status == "passed"
+    assert report.canary_ok is True
     assert report.detail_url_ok is True
 
 
@@ -142,6 +143,7 @@ def test_validate_timeanddate_eclipses_fails_canary_when_timeline_is_missing(tmp
     report = adapter.validate(2026)
 
     assert report.status == "failed"
+    assert report.canary_ok is False
     assert report.reason == (
         "unable to derive eclipse identity: "
         "https://www.timeanddate.com/eclipse/lunar/2026-march-3"
@@ -167,6 +169,7 @@ def test_validate_timeanddate_eclipses_checks_all_configured_pages(tmp_path: Pat
     report = adapter.validate(2026)
 
     assert report.status == "failed"
+    assert report.canary_ok is False
     assert report.reason == (
         "unable to derive eclipse identity: "
         "https://www.timeanddate.com/eclipse/solar/2026-august-12"

--- a/tests/test_usno_moon_phases.py
+++ b/tests/test_usno_moon_phases.py
@@ -82,3 +82,26 @@ def test_content_hash_is_deterministic_for_same_fixture(tmp_path: Path) -> None:
     assert [candidate.content_hash for candidate in first] == [
         candidate.content_hash for candidate in second
     ]
+
+
+def test_validate_usno_moon_phases_fails_canary_when_required_field_is_missing(tmp_path: Path) -> None:
+    payload = {
+        "phasedata": [
+            {
+                "phase": "New Moon",
+                "year": 2026,
+                "month": 1,
+                "day": 1,
+            }
+        ]
+    }
+    adapter = MoonPhasesAdapter(
+        http_client=FixtureHttpClient(payload),
+        raw_store=RawStore(base_dir=tmp_path / "raw"),
+        now_provider=lambda: "2026-03-01T12:00:00Z",
+    )
+
+    report = adapter.validate(2026)
+
+    assert report.status == "failed"
+    assert report.reason == "missing required fields: time"

--- a/tests/test_usno_moon_phases.py
+++ b/tests/test_usno_moon_phases.py
@@ -46,6 +46,7 @@ def test_validate_usno_moon_phases_fixture_passes(tmp_path: Path) -> None:
     report = adapter.validate(2026)
 
     assert report.status == "passed"
+    assert report.canary_ok is True
     assert report.detail_url_ok is True
     assert "required timing fields present" in report.checks
 
@@ -104,4 +105,5 @@ def test_validate_usno_moon_phases_fails_canary_when_required_field_is_missing(t
     report = adapter.validate(2026)
 
     assert report.status == "failed"
+    assert report.canary_ok is False
     assert report.reason == "missing required fields: time"

--- a/tests/test_usno_moon_phases.py
+++ b/tests/test_usno_moon_phases.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from astrocal.adapters.astronomy.usno_moon_phases import MoonPhasesAdapter
-from astrocal.repositories import CandidateStore, RawStore
+from astrocal.repositories import CandidateStore, DiagnosticStore, RawStore
 from astrocal.services.normalize_service import normalize_source_family
 
 
@@ -83,6 +83,31 @@ def test_content_hash_is_deterministic_for_same_fixture(tmp_path: Path) -> None:
     assert [candidate.content_hash for candidate in first] == [
         candidate.content_hash for candidate in second
     ]
+
+
+def test_normalize_diagnostics_include_moon_phase_extraction_summary(tmp_path: Path) -> None:
+    adapter = build_adapter(tmp_path)
+
+    raw_result = adapter.fetch(2026)
+    normalize_source_family(
+        "astronomy",
+        2026,
+        adapters={"moon-phases": adapter},
+        raw_results=[raw_result],
+        candidate_store=CandidateStore(base_dir=tmp_path / "normalized"),
+        diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+    )
+
+    summary_path = (
+        tmp_path / "diagnostics" / "astronomy" / "2026" / "moon-phases" / "normalize-summary.json"
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert summary["extraction_summary"] == {
+        "phase_names": ["Full Moon", "New Moon"],
+        "first_start": "2026-01-03T10:03:00Z",
+        "last_start": "2026-01-18T17:52:00Z",
+    }
 
 
 def test_validate_usno_moon_phases_fails_canary_when_required_field_is_missing(tmp_path: Path) -> None:

--- a/tests/test_usno_seasons.py
+++ b/tests/test_usno_seasons.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 from astrocal.adapters.astronomy.usno_seasons import SeasonsAdapter
-from astrocal.repositories import CandidateStore, RawStore
+from astrocal.repositories import CandidateStore, DiagnosticStore, RawStore
 from astrocal.services.normalize_service import normalize_source_family
 
 
@@ -120,6 +120,30 @@ def test_normalize_usno_seasons_ignores_non_season_rows(tmp_path: Path) -> None:
     assert {candidate.title for candidate in candidates} == {
         "March Equinox",
         "June Solstice",
+    }
+
+
+def test_normalize_diagnostics_include_season_extraction_summary(tmp_path: Path) -> None:
+    adapter = build_adapter(tmp_path)
+
+    raw_result = adapter.fetch(2026)
+    normalize_source_family(
+        "astronomy",
+        2026,
+        adapters={"seasons": adapter},
+        raw_results=[raw_result],
+        candidate_store=CandidateStore(base_dir=tmp_path / "normalized"),
+        diagnostic_store=DiagnosticStore(base_dir=tmp_path / "diagnostics"),
+    )
+
+    summary_path = (
+        tmp_path / "diagnostics" / "astronomy" / "2026" / "seasons" / "normalize-summary.json"
+    )
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+    assert summary["extraction_summary"] == {
+        "titles_seen": ["June Solstice", "March Equinox"],
+        "ignored_non_season_row_count": 2,
     }
 
 

--- a/tests/test_usno_seasons.py
+++ b/tests/test_usno_seasons.py
@@ -119,3 +119,28 @@ def test_normalize_usno_seasons_ignores_non_season_rows(tmp_path: Path) -> None:
         "March Equinox",
         "June Solstice",
     }
+
+
+def test_validate_usno_seasons_fails_canary_when_no_season_rows_exist(tmp_path: Path) -> None:
+    payload = {
+        "year": 2026,
+        "data": [
+            {
+                "year": 2026,
+                "month": 1,
+                "day": 3,
+                "time": "17:15",
+                "phenom": "Perihelion",
+            }
+        ],
+    }
+    adapter = SeasonsAdapter(
+        http_client=FixtureHttpClient(payload),
+        raw_store=RawStore(base_dir=tmp_path / "raw"),
+        now_provider=lambda: "2026-03-01T12:00:00Z",
+    )
+
+    report = adapter.validate(2026)
+
+    assert report.status == "failed"
+    assert report.reason == "season-marker data missing"

--- a/tests/test_usno_seasons.py
+++ b/tests/test_usno_seasons.py
@@ -46,6 +46,7 @@ def test_validate_usno_seasons_fixture_passes(tmp_path: Path) -> None:
     report = adapter.validate(2026)
 
     assert report.status == "passed"
+    assert report.canary_ok is True
     assert report.detail_url_ok is True
     assert "required timing fields present" in report.checks
 
@@ -107,6 +108,7 @@ def test_validate_usno_seasons_accepts_generic_usno_labels(tmp_path: Path) -> No
     report = adapter.validate(2026)
 
     assert report.status == "passed"
+    assert report.canary_ok is True
 
 
 def test_normalize_usno_seasons_ignores_non_season_rows(tmp_path: Path) -> None:
@@ -143,4 +145,5 @@ def test_validate_usno_seasons_fails_canary_when_no_season_rows_exist(tmp_path: 
     report = adapter.validate(2026)
 
     assert report.status == "failed"
+    assert report.canary_ok is False
     assert report.reason == "season-marker data missing"


### PR DESCRIPTION
## Summary
- add canary-style drift checks for the current astronomy source adapters
- persist validation, fetch, and normalize diagnostics for source-boundary debugging
- enrich normalize diagnostics with compact adapter-specific extraction summaries

## What Changed
- added shared canary validation helpers and applied them to moon phases, seasons, and eclipses
- strengthened eclipse validation to check every configured canary detail page
- exposed `canary_ok` in validation reports
- added a diagnostic store under `data/diagnostics/` for validation, fetch, and normalize artifacts
- persisted normalize failure artifacts and compact summaries for successful runs
- added adapter-specific extraction summaries for moon phases, seasons, and eclipses
- documented the canary validation contract and source-boundary diagnostic artifacts
- expanded fixture-backed coverage for malformed payloads and diagnostics output

## Verification
- `.venv/bin/python -m pytest tests`

## Follow-ups
- #11 applies the same drift-check pattern to future planetary adapters
- #12 adds the repo-specific debugging skill on top of these artifacts

Closes #2
Closes #3
Closes #13