### PR TITLE
Add a source-adapter debugging skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Available calendars:
 | Equinoxes and Solstices | March Equinox, June Solstice, September Equinox, and December Solstice |
 | Eclipses | Solar and lunar eclipses with exact astronomical timing |
 
-## Status
+## Current Source Coverage
 
-Phase 1 is live for astronomy sources:
+AstronomicalCalendars currently publishes calendars backed by:
 
 - USNO moon phases
 - USNO seasons

--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ make install
 .venv/bin/python -m astrocal validate astronomy --year 2026
 .venv/bin/python -m astrocal run --calendar astronomy-all --year 2026
 ```
+
+## Maintainer Notes
+
+For source-boundary failures, use
+[`skills/debug-source-adapters/SKILL.md`](skills/debug-source-adapters/SKILL.md) to inspect
+reports, diagnostics, raw snapshots, normalized candidates, and reconciliation artifacts in
+a fixed order.

--- a/skills/debug-source-adapters/SKILL.md
+++ b/skills/debug-source-adapters/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: debug-source-adapters
+description: Debug validation, fetch, parsing, normalization, and reconciliation failures at the external-source boundary for astronomy and future source adapters. Use when Codex needs to inspect validation reports, diagnostics under data/diagnostics, raw payload snapshots, normalized candidate output, or reconciliation reports to classify why a source-backed run failed.
+---
+
+# Debug Source Adapters
+
+Debug the source boundary in a fixed order. Treat [`specs/`](../../specs) as the source of
+truth for contracts and expected artifacts.
+
+## Workflow
+
+1. Read [`specs/source-policy.md`](../../specs/source-policy.md).
+2. Read the relevant JSON report under [`data/catalog/reports/`](../../data/catalog/reports).
+3. Read the source summary under `data/diagnostics/<source-type>/<year>/<source-name>/`:
+   - `validate-summary.json`
+   - `fetch-summary.json` or `fetch-failure.json`
+   - `normalize-summary.json` or `normalize-failure.json`
+4. If fetch succeeded, inspect the raw snapshot under [`data/raw/`](../../data/raw).
+5. If normalization succeeded, inspect the normalized candidates under
+   [`data/normalized/`](../../data/normalized).
+6. If reconciliation ran, inspect the reconciliation report and accepted catalog output.
+7. Classify the failure before proposing a fix.
+
+## Failure Classes
+
+Use one primary classification:
+
+- `network-or-reachability`
+- `source-shape-drift`
+- `detail-url-derivation`
+- `fetch-failure`
+- `parsing-or-extraction`
+- `normalization-failure`
+- `reconciliation-mismatch`
+
+## What To Check
+
+### Validation
+
+- `status`
+- `reason`
+- `checks`
+- `canary_ok`
+- `detail_url_ok`
+- `source_url`
+
+If validation failed, stop there unless the raw payload was already saved by a previous run.
+
+### Fetch
+
+- whether `fetch-summary.json` exists
+- `raw_ref`
+- source adapter and source URL
+- any `fetch-failure.json` reason
+
+### Normalize
+
+- `candidate_count`
+- `event_types`
+- `variants`
+- `titles_sample`
+- `metadata_keys`
+- `extraction_summary`
+- any `normalize-failure.json` reason
+
+Use `extraction_summary` to quickly sanity-check what the parser claims it found before
+opening the full candidate file.
+
+### Reconciliation
+
+- whether the candidate set got far enough to reconcile
+- whether the accepted catalog changed unexpectedly
+- whether a source failure should have stopped reconciliation earlier
+
+## Output Expectations
+
+When reporting a debugging result:
+
+1. Name the failure class.
+2. Cite the exact artifact(s) inspected.
+3. State the concrete failing field, page marker, or parser assumption.
+4. Identify the smallest likely fix location.
+
+Keep the diagnosis artifact-driven. Do not speculate about upstream payload shape when a
+saved raw snapshot or diagnostic artifact exists.

--- a/skills/debug-source-adapters/agents/openai.yaml
+++ b/skills/debug-source-adapters/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Debug Source Adapters"
+  short_description: "Diagnose source-boundary failures"
+  default_prompt: "Use $debug-source-adapters to inspect source-boundary reports, diagnostics, raw snapshots, normalized candidates, and reconciliation artifacts before proposing a fix."
+
+policy:
+  allow_implicit_invocation: true

--- a/skills/source-astronomy-events/SKILL.md
+++ b/skills/source-astronomy-events/SKILL.md
@@ -20,6 +20,9 @@ Treat `specs/` as the source of truth for source selection, validation, and sche
    [`specs/normalized-event-schema.md`](../../specs/normalized-event-schema.md).
 8. Write normalized output under `data/normalized/astronomy/...`.
 
+If validation, fetch, or normalization fails, use
+[`debug-source-adapters`](../debug-source-adapters/SKILL.md) before changing parser logic.
+
 ## Output Expectations
 
 Expected outputs:


### PR DESCRIPTION
## Summary
- add a repo-local skill for debugging source-boundary failures
- surface that skill from the astronomy source skill and the root README
- remove remaining milestone language from the README source-coverage copy

## What Changed
- added `skills/debug-source-adapters/` with a deterministic troubleshooting workflow
- documented the fixed inspection order: validation report, diagnostics, raw snapshot, normalized candidates, and reconciliation artifacts
- defined the primary failure classes for source-boundary debugging
- cross-linked the debugging skill from `skills/source-astronomy-events/SKILL.md`
- added a brief maintainer-facing pointer in `README.md`

## Notes
- this skill is workflow-oriented and defers behavior/contracts to `specs/source-policy.md`
- no runtime code changed in this PR

Closes #12