### PR TITLE
Add an LLM-operable eclipse review workflow with a minimal CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ make install
 
 1. Run `.venv/bin/python -m astrocal reconcile --calendar astronomy-eclipses --year 2026`
    or the equivalent `run` flow.
-2. Review `data/catalog/reports/<run_timestamp>/review.astronomy-eclipses.md`.
-3. If the facts are correct, accept or edit the generated eclipse title, summary, and
-   description in `data/catalog/accepted/astronomy/2026/eclipses.json`.
-4. If the facts are wrong, correct the accepted record content and mark the review outcome
-   accordingly.
+2. Review the generated artifacts:
+   - `data/catalog/reports/<run_timestamp>/review.astronomy-eclipses.md`
+   - `data/catalog/reports/<run_timestamp>/review.astronomy-eclipses.json`
+   - or inspect the persisted bundle with
+     `.venv/bin/python -m astrocal show-review --report data/catalog/reports/<run_timestamp>/review.astronomy-eclipses.json`
+3. List pending persisted review bundles at any time with
+   `.venv/bin/python -m astrocal list-pending-reviews`.
+4. Approve reviewed content without editing accepted catalog JSON directly:
+   - accept as-is with
+     `.venv/bin/python -m astrocal approve-review --report data/catalog/reports/<run_timestamp>/review.astronomy-eclipses.json --reviewer <name> --occurrence-id <occurrence-id>`
+   - or approve edited prose by also passing `--title`, `--summary`, and `--description-file`
 5. Rebuild the published calendar from accepted records with
    `.venv/bin/python -m astrocal build --calendar astronomy-eclipses`.
 

--- a/docs/plans/2026-03-03-issue-20-eclipse-approval-workflow.md
+++ b/docs/plans/2026-03-03-issue-20-eclipse-approval-workflow.md
@@ -1,0 +1,422 @@
+# Issue 20 LLM-Operable Eclipse Review Workflow Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a safe, human-controlled eclipse review workflow that is easy for either a human or an LLM to run end-to-end without hand-editing `data/catalog/accepted/.../eclipses.json`.
+
+**Architecture:** Keep the existing Markdown review report for humans, but add a structured review bundle that captures the candidate snapshot, accepted baseline, and allowed next actions for each reviewed eclipse occurrence. Expose the workflow through explicit CLI verbs such as `list-pending-reviews`, `show-review`, and `approve-review`, backed by a dedicated promotion service that is the only path allowed to write accepted eclipse revisions. Treat the persisted review bundle as the workflow boundary so either a human or an LLM can stop after generation, inspect the state later, approve changes explicitly, and resume the publish flow safely. Do not build the MCP transport layer in this PR; that is the immediate follow-on in Issue #22.
+
+**Tech Stack:** Python 3, argparse CLI, dataclasses, existing `astrocal` repositories/services, pytest.
+
+---
+
+## Implementation Decisions
+
+- Use a new machine-readable artifact beside the Markdown review report:
+  - `data/catalog/reports/<run_timestamp>/review.<manifest>.json`
+  - Keep `review.<manifest>.md` as the human review surface.
+- Add explicit review-management commands:
+  - `astrocal list-pending-reviews`
+  - `astrocal show-review --report <path> --format markdown|json`
+  - `astrocal approve-review --report <path> --reviewer <name> --occurrence-id <id>`
+  - Support `--group-id <id>` for accept-as-is bulk approval only.
+  - Support `--resolution accepted|prose-edited|facts-corrected`, `--note`, `--title`, `--summary`, and `--description-file`.
+- Keep the workflow resumable.
+  - `run` may stop after generating review artifacts.
+  - A later command may inspect, approve, and continue from disk state.
+- Do not let the CLI mutate accepted revisions in place.
+  - Every approval writes a new active `AcceptedRecord` revision and supersedes the previous active revision.
+- Persist enough review provenance to avoid repeated review churn.
+  - Preserve the generated-candidate provenance already stored in `description_provenance`.
+  - Add `generated_content_hash` to the accepted eclipse provenance so reconciliation can tell whether the reviewed candidate snapshot has changed.
+- Put enough structure in the review bundle for LLM operation.
+  - Each review entry should include candidate content, accepted baseline content, fact bundle, hashes, source references, and allowed actions.
+- Treat accepted human prose as stable if the reviewed candidate snapshot is unchanged.
+  - If facts and generated content are unchanged since review, reconciliation should not open another review just because accepted prose differs from the generated candidate.
+- Keep `.ics` generation unchanged.
+  - `build` continues to publish only active accepted catalog records.
+- Defer the local MCP transport layer.
+  - Issue #22 should wrap the settled service/CLI surface instead of co-evolving with it in this PR.
+
+## Recommended Commit Story
+
+1. `docs: define llm-operable eclipse review workflow`
+2. `feat: emit structured eclipse review bundles`
+3. `feat: add review inspection commands`
+4. `feat: add eclipse review approval service`
+5. `feat: preserve approved eclipse edits across reconcile`
+6. `test: cover minimal review cli workflow end to end`
+
+### Task 1: Codify The Approval Contract
+
+**Files:**
+- Create: `specs/eclipse-review-approval-workflow.md`
+- Modify: `README.md`
+- Modify: `specs/event-catalog-schema.md`
+- Modify: `specs/eclipse-description-fact-bundle.md`
+- Modify: `specs/architecture.md`
+
+**Step 1: Write the contract updates**
+
+- Define the v1 workflow:
+  - `reconcile` writes both `review.<manifest>.md` and `review.<manifest>.json`
+  - reviewer or LLM inspects the persisted review bundle
+  - reviewer or LLM runs `approve-review`
+  - `build` still reads only accepted records
+- Document the structured review bundle contents:
+  - manifest name
+  - year
+  - run timestamp
+  - occurrence/group ids
+  - candidate snapshot
+  - accepted baseline snapshot
+  - candidate `content_hash`
+  - candidate description provenance, including `facts_hash` and `prompt_version`
+  - source references and allowed actions
+- Document the inspection commands:
+  - `list-pending-reviews`
+  - `show-review`
+- Document the approval command inputs and the meaning of:
+  - `resolution=accepted`
+  - `resolution=prose-edited`
+  - `resolution=facts-corrected`
+- Document the new provenance rule:
+  - accepted eclipse records store `description_provenance.generated_content_hash`
+  - accepted eclipse records never require direct JSON editing in the normal path
+- Document the orchestration rule:
+  - any future orchestration layer or MCP server must reuse the same persisted review bundle and approval service
+- Document the follow-on boundary:
+  - the local MCP server is tracked separately in #22
+
+**Step 2: Review the wording for consistency**
+
+Check that the docs all point to:
+- `data/catalog/reports/<run_timestamp>/review.<manifest>.md`
+- `data/catalog/reports/<run_timestamp>/review.<manifest>.json`
+- `data/catalog/accepted/astronomy/<year>/eclipses.json`
+
+**Step 3: Commit**
+
+```bash
+git add specs/eclipse-review-approval-workflow.md README.md specs/event-catalog-schema.md specs/eclipse-description-fact-bundle.md specs/architecture.md
+git commit -m "docs: define llm-operable eclipse review workflow"
+```
+
+### Task 2: Add Typed Review Bundle And Inspection Metadata
+
+**Files:**
+- Create: `src/astrocal/models/review.py`
+- Modify: `src/astrocal/models/catalog.py`
+- Modify: `src/astrocal/models/reports.py`
+- Modify: `src/astrocal/models/__init__.py`
+- Modify: `tests/test_repositories.py`
+
+**Step 1: Write the failing tests**
+
+Add tests that cover:
+- serializing and loading a structured review bundle entry with:
+  - `occurrence_id`
+  - `group_id`
+  - candidate snapshot
+  - accepted baseline snapshot or `null`
+  - `candidate_content_hash`
+  - `generated_content_hash`
+  - allowed actions
+- accepted eclipse metadata round-tripping with:
+  - `description_provenance.generated_content_hash`
+  - `description_review.edited`
+  - `description_review.resolution`
+- `ReconciliationReport` carrying both:
+  - `review_report_path`
+  - `review_bundle_path`
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_repositories.py -v`
+Expected: FAIL because the review bundle model and extra report field do not exist.
+
+**Step 3: Write the minimal implementation**
+
+- Add lightweight review dataclasses, for example:
+  - `ReviewBundle`
+  - `ReviewBundleEntry`
+- Give `ReviewBundleEntry` fields that an LLM can consume directly without re-deriving state from unrelated files.
+- Export the new types through `src/astrocal/models/__init__.py`.
+- Extend `ReconciliationReport` with `review_bundle_path`.
+- Keep catalog metadata as plain dictionaries, but define constants or thin helpers for:
+  - `generated_content_hash`
+  - allowed review resolutions
+
+**Step 4: Run the focused tests again**
+
+Run: `pytest tests/test_repositories.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/astrocal/models/review.py src/astrocal/models/catalog.py src/astrocal/models/reports.py src/astrocal/models/__init__.py tests/test_repositories.py
+git commit -m "feat: add typed eclipse review bundle models"
+```
+
+### Task 3: Emit Structured Review Bundles During Reconcile
+
+**Files:**
+- Modify: `src/astrocal/services/reconcile_service.py`
+- Modify: `src/astrocal/services/review_report_service.py`
+- Modify: `src/astrocal/repositories/report_store.py`
+- Modify: `tests/test_reconcile_service.py`
+- Modify: `tests/test_review_report_service.py`
+
+**Step 1: Write the failing tests**
+
+Add coverage that:
+- eclipse reconcile writes `review.<manifest>.json` beside `review.<manifest>.md`
+- the JSON bundle contains one entry per new or changed reviewed eclipse occurrence
+- each bundle entry includes the active accepted baseline revision when one exists
+- suspected removals appear in the structured artifact with the last active accepted snapshot
+- `ReconciliationReport.review_bundle_path` is populated
+- pending review entries expose enough data for `show-review` without reopening accepted catalog files
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_reconcile_service.py tests/test_review_report_service.py -v`
+Expected: FAIL because reconcile currently emits only the Markdown review artifact.
+
+**Step 3: Write the minimal implementation**
+
+- Add a small helper in `reconcile_service.py` that converts eclipse review data into a `ReviewBundle`.
+- Write the JSON bundle through `ReportStore.write_json_report(...)`.
+- Keep the Markdown renderer human-focused.
+- Do not put approval logic into the report writer; the artifact should be data-only.
+
+**Step 4: Run the focused tests again**
+
+Run: `pytest tests/test_reconcile_service.py tests/test_review_report_service.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/astrocal/services/reconcile_service.py src/astrocal/services/review_report_service.py src/astrocal/repositories/report_store.py tests/test_reconcile_service.py tests/test_review_report_service.py
+git commit -m "feat: emit structured eclipse review bundles"
+```
+
+### Task 4: Add Review Inspection Commands
+
+**Files:**
+- Modify: `src/astrocal/cli.py`
+- Modify: `src/astrocal/services/stub_service.py`
+- Create: `src/astrocal/services/review_query_service.py`
+- Modify: `tests/test_cli.py`
+
+**Step 1: Write the failing tests**
+
+Add CLI coverage that:
+- `astrocal list-pending-reviews` prints pending review bundle paths and manifest/year context
+- `astrocal show-review --report <path> --format json` prints the structured bundle entry
+- `astrocal show-review --report <path> --format markdown` prints a readable summary of the same review state
+- missing or malformed review bundle paths fail clearly
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_cli.py -v`
+Expected: FAIL because the CLI has no review inspection commands.
+
+**Step 3: Write the minimal implementation**
+
+- Add a small query service that:
+  - discovers pending review bundles under `data/catalog/reports`
+  - loads a chosen bundle
+  - renders a concise inspection summary
+- Keep these commands read-only.
+- Make the output deterministic and compact so an LLM can consume it reliably.
+
+**Step 4: Run the focused tests again**
+
+Run: `pytest tests/test_cli.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/astrocal/cli.py src/astrocal/services/stub_service.py src/astrocal/services/review_query_service.py tests/test_cli.py
+git commit -m "feat: add review inspection commands"
+```
+
+### Task 5: Implement The Approval Promotion Service
+
+**Files:**
+- Create: `src/astrocal/services/review_approval_service.py`
+- Modify: `src/astrocal/repositories/catalog_store.py`
+- Modify: `src/astrocal/models/catalog.py`
+- Create: `tests/test_review_approval_service.py`
+
+**Step 1: Write the failing tests**
+
+Add service tests for:
+- approving a new reviewed eclipse occurrence creates revision `1`
+- approving a changed reviewed eclipse occurrence supersedes the current active revision and appends the new active revision
+- accepting generated prose as-is copies the candidate title, summary, description, and provenance
+- approving edited prose applies the override fields and records:
+  - `description_review.edited = true`
+  - `description_review.resolution = "prose-edited"`
+  - `description_review.reviewer`
+  - `description_review.note`
+- approving corrected facts uses `resolution = "facts-corrected"`
+- top-level `AcceptedRecord.content_hash` is recomputed from the final accepted payload after edits
+- the service rejects stale approvals if the current accepted active revision no longer matches the review bundle baseline
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_review_approval_service.py -v`
+Expected: FAIL because no approval service exists.
+
+**Step 3: Write the minimal implementation**
+
+- Add a single service entry point, for example:
+
+```python
+approve_review_entry(
+    review_bundle_path: Path,
+    reviewer: str,
+    occurrence_ids: list[str],
+    group_ids: list[str],
+    resolution: str,
+    note: str | None,
+    title: str | None,
+    summary: str | None,
+    description: str | None,
+) -> list[AcceptedRecord]
+```
+
+- Keep the promotion flow strict:
+  - load the review bundle entry
+  - validate that the current accepted baseline still matches
+  - create a new accepted payload from the candidate snapshot
+  - apply optional prose overrides
+  - attach `description_review`
+  - preserve `description_provenance` and set `generated_content_hash`
+  - supersede the previous active revision if present
+  - save the updated catalog file
+
+**Step 4: Run the focused tests again**
+
+Run: `pytest tests/test_review_approval_service.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/astrocal/services/review_approval_service.py src/astrocal/repositories/catalog_store.py src/astrocal/models/catalog.py tests/test_review_approval_service.py
+git commit -m "feat: add eclipse review approval service"
+```
+
+### Task 6: Keep Approved Human Edits Stable Across Reconcile
+
+**Files:**
+- Modify: `src/astrocal/services/reconcile_service.py`
+- Modify: `tests/test_reconcile_service.py`
+- Modify: `tests/test_services.py`
+
+**Step 1: Write the failing tests**
+
+Add coverage that:
+- a previously approved `prose-edited` eclipse record is treated as unchanged when:
+  - the incoming candidate has the same `content_hash` as the reviewed generated candidate
+  - the accepted record differs only in human-edited title, summary, or description
+- a new review is still required when:
+  - the candidate facts hash changes
+  - the generated content hash changes
+  - non-prose fields such as timing or detail URL change
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_reconcile_service.py tests/test_services.py -v`
+Expected: FAIL because reconcile currently compares accepted and candidate `content_hash` directly.
+
+**Step 3: Write the minimal implementation**
+
+- Add a helper in `reconcile_service.py` that recognizes an approved eclipse review state.
+- Treat a reviewed human prose edit as unchanged only when:
+  - `description_review.status == "accepted"`
+  - accepted `description_provenance.generated_content_hash == candidate.content_hash`
+  - the candidate provenance facts hash still matches the accepted provenance facts hash
+  - non-generated fields still match
+- Keep this behavior scoped to eclipse records with review metadata; do not change moon phase or season reconciliation.
+
+**Step 4: Run the focused tests again**
+
+Run: `pytest tests/test_reconcile_service.py tests/test_services.py -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/astrocal/services/reconcile_service.py tests/test_reconcile_service.py tests/test_services.py
+git commit -m "feat: preserve approved eclipse edits across reconcile"
+```
+
+### Task 7: Wire The Minimal Human CLI Workflow
+
+**Files:**
+- Modify: `src/astrocal/cli.py`
+- Modify: `src/astrocal/services/stub_service.py`
+- Modify: `src/astrocal/services/run_service.py`
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_services.py`
+- Modify: `README.md`
+
+**Step 1: Write the failing tests**
+
+Add CLI and integration coverage that:
+- `astrocal run --calendar astronomy-eclipses --year 2026` prints both review artifact paths and exits cleanly when review is pending
+- `astrocal approve-review --report <path> --reviewer tester --occurrence-id <id> --resolution accepted` writes a new accepted revision
+- `astrocal approve-review ... --title ... --summary ... --description-file ... --resolution prose-edited` records the edited review metadata correctly
+- `astrocal approve-review --group-id <id>` approves multiple occurrences only when no override fields are supplied
+- `astrocal show-review` can be used immediately after `run` to inspect the generated review state
+- the command exits non-zero with a clear error when the review bundle is stale or the requested occurrence is missing
+- the `run` and `reconcile` flows print both the Markdown review path and the structured review bundle path when review is pending
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_cli.py tests/test_services.py -v`
+Expected: FAIL because the CLI lacks the full review-management surface and the report output only mentions Markdown review paths.
+
+**Step 3: Write the minimal implementation**
+
+- Add a new `approve-review` subparser in `src/astrocal/cli.py`.
+- Add `list-pending-reviews` and `show-review` subparsers in `src/astrocal/cli.py`.
+- Keep the mutation surface explicit and non-interactive for v1.
+- Reuse the new approval service from `stub_service.py` so CLI tests stay focused on argument handling and output.
+- Keep this PR at the service plus minimal human CLI boundary. Do not add MCP server wiring here.
+- Print a short success line that names:
+  - approved occurrence count
+  - accepted catalog path
+  - new revision numbers or count
+
+**Step 4: Run the focused tests again**
+
+Run: `pytest tests/test_cli.py tests/test_services.py -v`
+Expected: PASS
+
+**Step 5: Run the full regression suite**
+
+Run: `pytest -q`
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/astrocal/cli.py src/astrocal/services/stub_service.py src/astrocal/services/run_service.py tests/test_cli.py tests/test_services.py README.md
+git commit -m "test: cover minimal review cli workflow end to end"
+```
+
+## Notes For Execution
+
+- Prefer approving one occurrence first before adding group-level bulk approval.
+- Keep manual prose override support limited to `title`, `summary`, and `description` in v1.
+- Reject direct accepted-catalog mutation anywhere outside the approval service.
+- Do not change `.ics` generation rules; this issue is about safer accepted-catalog promotion only.
+- Treat the persisted review bundle as the pause/resume boundary for both humans and LLM-driven operation.
+- Treat Issue #22 as the immediate next step once this service/CLI surface is stable.

--- a/src/astrocal/cli.py
+++ b/src/astrocal/cli.py
@@ -9,8 +9,10 @@ from .services.run_service import run_command
 from .services.stub_service import (
     build_command,
     fetch_command,
+    list_pending_reviews_command,
     normalize_command,
     reconcile_command,
+    show_review_command,
     validate_command,
 )
 
@@ -35,6 +37,15 @@ def build_parser() -> argparse.ArgumentParser:
     reconcile_parser.add_argument("--year", type=int, required=True)
     reconcile_parser.add_argument("--report-dir", type=Path)
     reconcile_parser.set_defaults(handler=reconcile_command)
+
+    list_pending_reviews_parser = subparsers.add_parser("list-pending-reviews")
+    list_pending_reviews_parser.add_argument("--report-dir", type=Path)
+    list_pending_reviews_parser.set_defaults(handler=list_pending_reviews_command)
+
+    show_review_parser = subparsers.add_parser("show-review")
+    show_review_parser.add_argument("--report", type=Path, required=True)
+    show_review_parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
+    show_review_parser.set_defaults(handler=show_review_command)
 
     build_parser = subparsers.add_parser("build")
     build_parser.add_argument("--calendar", required=True)

--- a/src/astrocal/cli.py
+++ b/src/astrocal/cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .services.run_service import run_command
 from .services.stub_service import (
+    approve_review_command,
     build_command,
     fetch_command,
     list_pending_reviews_command,
@@ -46,6 +47,23 @@ def build_parser() -> argparse.ArgumentParser:
     show_review_parser.add_argument("--report", type=Path, required=True)
     show_review_parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
     show_review_parser.set_defaults(handler=show_review_command)
+
+    approve_review_parser = subparsers.add_parser("approve-review")
+    approve_review_parser.add_argument("--report", type=Path, required=True)
+    approve_review_parser.add_argument("--reviewer", required=True)
+    approve_review_parser.add_argument("--occurrence-id", action="append", default=[])
+    approve_review_parser.add_argument("--group-id", action="append", default=[])
+    approve_review_parser.add_argument(
+        "--resolution",
+        choices=["accepted", "prose-edited", "facts-corrected"],
+        default="accepted",
+    )
+    approve_review_parser.add_argument("--note")
+    approve_review_parser.add_argument("--title")
+    approve_review_parser.add_argument("--summary")
+    approve_review_parser.add_argument("--description-file", type=Path)
+    approve_review_parser.add_argument("--catalog-dir", type=Path)
+    approve_review_parser.set_defaults(handler=approve_review_command)
 
     build_parser = subparsers.add_parser("build")
     build_parser.add_argument("--calendar", required=True)

--- a/src/astrocal/cli.py
+++ b/src/astrocal/cli.py
@@ -42,6 +42,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     list_pending_reviews_parser = subparsers.add_parser("list-pending-reviews")
     list_pending_reviews_parser.add_argument("--report-dir", type=Path)
+    list_pending_reviews_parser.add_argument("--catalog-dir", type=Path)
     list_pending_reviews_parser.set_defaults(handler=list_pending_reviews_command)
 
     show_review_parser = subparsers.add_parser("show-review")

--- a/src/astrocal/cli.py
+++ b/src/astrocal/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 from .services.run_service import run_command
@@ -90,4 +91,8 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    return int(args.handler(args))
+    try:
+        return int(args.handler(args))
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1

--- a/src/astrocal/models/__init__.py
+++ b/src/astrocal/models/__init__.py
@@ -7,7 +7,12 @@ from .candidate import (
     SourceReference,
     ValidationResult,
 )
-from .catalog import AcceptedRecord, DESCRIPTION_PROVENANCE_KEY, DESCRIPTION_REVIEW_KEY
+from .catalog import (
+    AcceptedRecord,
+    DESCRIPTION_PROVENANCE_KEY,
+    DESCRIPTION_REVIEW_KEY,
+    GENERATED_CONTENT_HASH_KEY,
+)
 from .manifest import CalendarManifest
 from .reports import BuildReport, RawFetchResult, ReconciliationReport, ValidationReport
 from .review import ReviewBundle, ReviewBundleEntry
@@ -21,6 +26,7 @@ __all__ = [
     "DESCRIPTION_PROVENANCE_KEY",
     "DESCRIPTION_REVIEW_KEY",
     "ECLIPSE_FACTS_SCHEMA_VERSION",
+    "GENERATED_CONTENT_HASH_KEY",
     "RawFetchResult",
     "ReconciliationReport",
     "ReviewBundle",

--- a/src/astrocal/models/__init__.py
+++ b/src/astrocal/models/__init__.py
@@ -10,6 +10,7 @@ from .candidate import (
 from .catalog import AcceptedRecord, DESCRIPTION_PROVENANCE_KEY, DESCRIPTION_REVIEW_KEY
 from .manifest import CalendarManifest
 from .reports import BuildReport, RawFetchResult, ReconciliationReport, ValidationReport
+from .review import ReviewBundle, ReviewBundleEntry
 
 __all__ = [
     "AcceptedRecord",
@@ -22,6 +23,8 @@ __all__ = [
     "ECLIPSE_FACTS_SCHEMA_VERSION",
     "RawFetchResult",
     "ReconciliationReport",
+    "ReviewBundle",
+    "ReviewBundleEntry",
     "SourceReference",
     "ValidationReport",
     "ValidationResult",

--- a/src/astrocal/models/catalog.py
+++ b/src/astrocal/models/catalog.py
@@ -7,6 +7,7 @@ from typing import Any
 
 DESCRIPTION_PROVENANCE_KEY = "description_provenance"
 DESCRIPTION_REVIEW_KEY = "description_review"
+GENERATED_CONTENT_HASH_KEY = "generated_content_hash"
 
 
 @dataclass(slots=True)

--- a/src/astrocal/models/reports.py
+++ b/src/astrocal/models/reports.py
@@ -41,6 +41,7 @@ class ReconciliationReport:
     year: int
     generated_at: str
     review_report_path: str | None = None
+    review_bundle_path: str | None = None
     new_occurrences: list[str] = field(default_factory=list)
     unchanged_occurrences: list[str] = field(default_factory=list)
     changed_occurrences: list[str] = field(default_factory=list)

--- a/src/astrocal/models/review.py
+++ b/src/astrocal/models/review.py
@@ -1,0 +1,65 @@
+"""Structured review bundle models."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class ReviewBundleEntry:
+    occurrence_id: str
+    group_id: str
+    status: str
+    source_name: str
+    candidate_content_hash: str | None
+    generated_content_hash: str | None
+    allowed_actions: list[str] = field(default_factory=list)
+    candidate: dict[str, Any] | None = None
+    accepted: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ReviewBundleEntry":
+        return cls(
+            occurrence_id=payload["occurrence_id"],
+            group_id=payload["group_id"],
+            status=payload["status"],
+            source_name=payload["source_name"],
+            candidate_content_hash=payload.get("candidate_content_hash"),
+            generated_content_hash=payload.get("generated_content_hash"),
+            allowed_actions=list(payload.get("allowed_actions", [])),
+            candidate=dict(payload["candidate"]) if isinstance(payload.get("candidate"), dict) else None,
+            accepted=dict(payload["accepted"]) if isinstance(payload.get("accepted"), dict) else None,
+        )
+
+
+@dataclass(slots=True)
+class ReviewBundle:
+    calendar_name: str
+    year: int
+    generated_at: str
+    entries: list[ReviewBundleEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "calendar_name": self.calendar_name,
+            "year": self.year,
+            "generated_at": self.generated_at,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> "ReviewBundle":
+        return cls(
+            calendar_name=payload["calendar_name"],
+            year=int(payload["year"]),
+            generated_at=payload["generated_at"],
+            entries=[
+                ReviewBundleEntry.from_dict(item)
+                for item in payload.get("entries", [])
+                if isinstance(item, dict)
+            ],
+        )

--- a/src/astrocal/services/reconcile_service.py
+++ b/src/astrocal/services/reconcile_service.py
@@ -8,7 +8,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from ..adapters import ASTRONOMY_ADAPTERS
-from ..models import AcceptedRecord, CalendarManifest, CandidateRecord, ReconciliationReport
+from ..models import (
+    AcceptedRecord,
+    CalendarManifest,
+    CandidateRecord,
+    ReconciliationReport,
+    ReviewBundle,
+    ReviewBundleEntry,
+)
 from ..repositories import CandidateStore, CatalogStore, ReportStore
 from ..source_scope import manifest_source_names
 from .review_report_service import render_review_report
@@ -103,6 +110,19 @@ def reconcile_calendar(
 
     written_paths = list(catalog_paths)
     if eclipse_new_candidates or eclipse_changed_pairs or eclipse_suspected_removals:
+        review_bundle = _build_review_bundle(
+            manifest=manifest,
+            year=year,
+            new_candidates=eclipse_new_candidates,
+            changed_pairs=eclipse_changed_pairs,
+            suspected_removals=eclipse_suspected_removals,
+            generated_at=run_timestamp,
+        )
+        review_bundle_path = report_store.write_json_report(
+            run_timestamp,
+            f"review.{manifest.name}",
+            review_bundle.to_dict(),
+        )
         review_report = render_review_report(
             manifest=manifest,
             year=year,
@@ -116,6 +136,8 @@ def reconcile_calendar(
             review_report,
         )
         report.review_report_path = str(review_path)
+        report.review_bundle_path = str(review_bundle_path)
+        written_paths.append(review_bundle_path)
         written_paths.append(review_path)
 
     report_name = f"reconcile.{manifest.name}"
@@ -252,6 +274,81 @@ def _change_reason(current: AcceptedRecord, candidate: CandidateRecord) -> str:
     if not changed_fields:
         return "Content hash changed"
     return f"Updated {', '.join(changed_fields)}"
+
+
+def _build_review_bundle(
+    *,
+    manifest: CalendarManifest,
+    year: int,
+    new_candidates: list[CandidateRecord],
+    changed_pairs: list[tuple[AcceptedRecord, CandidateRecord]],
+    suspected_removals: list[AcceptedRecord],
+    generated_at: str,
+) -> ReviewBundle:
+    entries: list[ReviewBundleEntry] = []
+    for candidate in new_candidates:
+        entries.append(_review_entry_for_candidate(candidate, status="new"))
+    for accepted, candidate in changed_pairs:
+        entries.append(_review_entry_for_candidate(candidate, status="changed", accepted=accepted))
+    for accepted in suspected_removals:
+        entries.append(_review_entry_for_suspected_removal(accepted))
+    return ReviewBundle(
+        calendar_name=manifest.name,
+        year=year,
+        generated_at=generated_at,
+        entries=entries,
+    )
+
+
+def _review_entry_for_candidate(
+    candidate: CandidateRecord,
+    *,
+    status: str,
+    accepted: AcceptedRecord | None = None,
+) -> ReviewBundleEntry:
+    return ReviewBundleEntry(
+        occurrence_id=candidate.occurrence_id,
+        group_id=candidate.group_id,
+        status=status,
+        source_name="eclipses",
+        candidate_content_hash=candidate.content_hash,
+        generated_content_hash=candidate.content_hash,
+        allowed_actions=[
+            "approve-as-is",
+            "approve-with-prose-edits",
+            "approve-with-fact-corrections",
+        ],
+        candidate=candidate.to_dict(),
+        accepted=accepted.to_dict() if accepted is not None else None,
+    )
+
+
+def _review_entry_for_suspected_removal(accepted: AcceptedRecord) -> ReviewBundleEntry:
+    group_id = str(accepted.record.get("group_id", accepted.occurrence_id.rsplit("/", 1)[0]))
+    return ReviewBundleEntry(
+        occurrence_id=accepted.occurrence_id,
+        group_id=group_id,
+        status="suspected-removed",
+        source_name="eclipses",
+        candidate_content_hash=None,
+        generated_content_hash=_accepted_generated_content_hash(accepted),
+        allowed_actions=["review-removal"],
+        candidate=None,
+        accepted=accepted.to_dict(),
+    )
+
+
+def _accepted_generated_content_hash(accepted: AcceptedRecord) -> str | None:
+    metadata = accepted.record.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return accepted.content_hash
+    provenance = metadata.get("description_provenance", {})
+    if not isinstance(provenance, dict):
+        return accepted.content_hash
+    generated_content_hash = provenance.get("generated_content_hash")
+    if isinstance(generated_content_hash, str) and generated_content_hash:
+        return generated_content_hash
+    return accepted.content_hash
 
 def _run_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")

--- a/src/astrocal/services/reconcile_service.py
+++ b/src/astrocal/services/reconcile_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -12,6 +13,9 @@ from ..models import (
     AcceptedRecord,
     CalendarManifest,
     CandidateRecord,
+    DESCRIPTION_PROVENANCE_KEY,
+    DESCRIPTION_REVIEW_KEY,
+    GENERATED_CONTENT_HASH_KEY,
     ReconciliationReport,
     ReviewBundle,
     ReviewBundleEntry,
@@ -227,6 +231,10 @@ def _reconcile_source_records(
             result.unchanged_occurrence_ids.append(candidate.occurrence_id)
             continue
 
+        if _matches_reviewed_eclipse_candidate(current, candidate):
+            result.unchanged_occurrence_ids.append(candidate.occurrence_id)
+            continue
+
         previous = AcceptedRecord.from_dict(current.to_dict())
         current.status = "superseded"
         current.superseded_at = accepted_at
@@ -349,6 +357,68 @@ def _accepted_generated_content_hash(accepted: AcceptedRecord) -> str | None:
     if isinstance(generated_content_hash, str) and generated_content_hash:
         return generated_content_hash
     return accepted.content_hash
+
+
+def _matches_reviewed_eclipse_candidate(
+    current: AcceptedRecord,
+    candidate: CandidateRecord,
+) -> bool:
+    if current.status != "active":
+        return False
+    if str(current.record.get("event_type")) != "eclipse":
+        return False
+
+    accepted_metadata = current.record.get("metadata", {})
+    candidate_metadata = candidate.metadata
+    if not isinstance(accepted_metadata, dict) or not isinstance(candidate_metadata, dict):
+        return False
+
+    review = accepted_metadata.get(DESCRIPTION_REVIEW_KEY, {})
+    if not isinstance(review, dict) or review.get("status") != "accepted":
+        return False
+
+    accepted_provenance = accepted_metadata.get(DESCRIPTION_PROVENANCE_KEY, {})
+    candidate_provenance = candidate_metadata.get(DESCRIPTION_PROVENANCE_KEY, {})
+    if not isinstance(accepted_provenance, dict) or not isinstance(candidate_provenance, dict):
+        return False
+
+    if accepted_provenance.get(GENERATED_CONTENT_HASH_KEY) != candidate.content_hash:
+        return False
+    if accepted_provenance.get("facts_hash") != candidate_provenance.get("facts_hash"):
+        return False
+
+    accepted_payload = _review_comparison_payload(current.record)
+    candidate_payload = _review_comparison_payload(candidate.to_dict())
+    return accepted_payload == candidate_payload
+
+
+def _review_comparison_payload(payload: dict[str, object]) -> dict[str, object]:
+    copy = json.loads(json.dumps(payload))
+    for field in (
+        "title",
+        "summary",
+        "description",
+        "content_hash",
+        "candidate_status",
+        "accepted_revision",
+        "first_seen_at",
+        "last_seen_at",
+    ):
+        if field in copy:
+            copy[field] = ""
+
+    source_validation = copy.get("source_validation")
+    if isinstance(source_validation, dict):
+        source_validation["validated_at"] = ""
+
+    metadata = copy.get("metadata", {})
+    if isinstance(metadata, dict):
+        metadata.pop(DESCRIPTION_REVIEW_KEY, None)
+        provenance = metadata.get(DESCRIPTION_PROVENANCE_KEY)
+        if isinstance(provenance, dict):
+            provenance["generated_at"] = ""
+            provenance.pop(GENERATED_CONTENT_HASH_KEY, None)
+    return copy
 
 def _run_timestamp() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")

--- a/src/astrocal/services/review_approval_service.py
+++ b/src/astrocal/services/review_approval_service.py
@@ -71,7 +71,15 @@ def approve_review(
 
     for entry in selected_entries:
         if entry.candidate is None:
-            raise ValueError(f"Review entry {entry.occurrence_id} cannot be approved from candidate data")
+            if entry.status == "suspected-removed":
+                raise ValueError(
+                    f"Review entry {entry.occurrence_id} is a suspected removal and "
+                    "cannot be approved with approve-review"
+                )
+            raise ValueError(
+                f"Review entry {entry.occurrence_id} has no candidate payload and "
+                "cannot be approved with approve-review"
+            )
         if entry.source_name != source_name:
             raise ValueError("Approving multiple source files in one command is not supported")
 

--- a/src/astrocal/services/review_approval_service.py
+++ b/src/astrocal/services/review_approval_service.py
@@ -1,0 +1,195 @@
+"""Promotion of reviewed eclipse content into the accepted catalog."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..hashing import sha256_text
+from ..models import (
+    AcceptedRecord,
+    CandidateRecord,
+    DESCRIPTION_PROVENANCE_KEY,
+    DESCRIPTION_REVIEW_KEY,
+    GENERATED_CONTENT_HASH_KEY,
+)
+from ..repositories import CatalogStore
+from .review_query_service import load_review_bundle
+
+REVIEW_RESOLUTIONS = {"accepted", "prose-edited", "facts-corrected"}
+
+
+@dataclass(slots=True)
+class ApprovalResult:
+    approved_records: list[AcceptedRecord]
+    catalog_path: Path
+
+
+def approve_review(
+    *,
+    report_path: Path,
+    reviewer: str,
+    occurrence_ids: list[str] | None = None,
+    group_ids: list[str] | None = None,
+    resolution: str = "accepted",
+    note: str | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+    description: str | None = None,
+    catalog_store: CatalogStore | None = None,
+    reviewed_at: str | None = None,
+) -> ApprovalResult:
+    if resolution not in REVIEW_RESOLUTIONS:
+        raise ValueError(f"Unsupported review resolution: {resolution}")
+
+    occurrence_ids = occurrence_ids or []
+    group_ids = group_ids or []
+    if not occurrence_ids and not group_ids:
+        raise ValueError("Specify at least one occurrence ID or group ID to approve")
+
+    bundle = load_review_bundle(report_path)
+    selected_entries = [
+        entry
+        for entry in bundle.entries
+        if entry.occurrence_id in occurrence_ids or entry.group_id in group_ids
+    ]
+    if not selected_entries:
+        raise ValueError("No matching review entries found")
+
+    if any([title, summary, description]) and len(selected_entries) != 1:
+        raise ValueError("Prose overrides require exactly one selected review entry")
+    if any([title, summary, description]) and group_ids:
+        raise ValueError("Group approval does not support per-entry prose overrides")
+
+    reviewed_at = reviewed_at or _reviewed_at()
+    catalog_store = catalog_store or CatalogStore()
+    source_name = selected_entries[0].source_name
+    accepted_records = catalog_store.load("astronomy", bundle.year, source_name)
+    approved_records: list[AcceptedRecord] = []
+
+    for entry in selected_entries:
+        if entry.candidate is None:
+            raise ValueError(f"Review entry {entry.occurrence_id} cannot be approved from candidate data")
+        if entry.source_name != source_name:
+            raise ValueError("Approving multiple source files in one command is not supported")
+
+        current = _current_active_record(accepted_records, entry.occurrence_id)
+        _validate_review_entry_is_current(entry, current)
+
+        if current is not None:
+            current.status = "superseded"
+            current.superseded_at = reviewed_at
+            next_revision = current.revision + 1
+        else:
+            next_revision = 1
+
+        candidate = CandidateRecord.from_dict(entry.candidate)
+        final_payload = candidate.to_dict()
+        if title is not None:
+            final_payload["title"] = title
+        if summary is not None:
+            final_payload["summary"] = summary
+        if description is not None:
+            final_payload["description"] = description
+
+        final_payload["accepted_revision"] = next_revision
+        final_payload["candidate_status"] = "accepted"
+        metadata = final_payload.setdefault("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+            final_payload["metadata"] = metadata
+        provenance = metadata.get(DESCRIPTION_PROVENANCE_KEY, {})
+        if not isinstance(provenance, dict):
+            provenance = {}
+        provenance[GENERATED_CONTENT_HASH_KEY] = candidate.content_hash
+        metadata[DESCRIPTION_PROVENANCE_KEY] = provenance
+        metadata[DESCRIPTION_REVIEW_KEY] = {
+            "status": "accepted",
+            "reviewed_at": reviewed_at,
+            "reviewer": reviewer,
+            "edited": any(value is not None for value in (title, summary, description)),
+            "resolution": resolution,
+            "note": note,
+        }
+
+        content_hash = _accepted_content_hash(final_payload)
+        final_payload["content_hash"] = content_hash
+        approved_record = AcceptedRecord(
+            occurrence_id=candidate.occurrence_id,
+            revision=next_revision,
+            status="active",
+            accepted_at=reviewed_at,
+            superseded_at=None,
+            change_reason=_approval_change_reason(current is None, resolution),
+            content_hash=content_hash,
+            source_adapter=candidate.source_adapter,
+            detail_url=candidate.detail_url,
+            record=final_payload,
+        )
+        accepted_records.append(approved_record)
+        approved_records.append(approved_record)
+
+    accepted_records.sort(key=lambda record: (record.occurrence_id, record.revision))
+    catalog_path = catalog_store.save("astronomy", bundle.year, source_name, accepted_records)
+    return ApprovalResult(approved_records=approved_records, catalog_path=catalog_path)
+
+
+def _current_active_record(
+    accepted_records: list[AcceptedRecord],
+    occurrence_id: str,
+) -> AcceptedRecord | None:
+    active = [
+        record
+        for record in accepted_records
+        if record.occurrence_id == occurrence_id and record.status == "active"
+    ]
+    if not active:
+        return None
+    return max(active, key=lambda record: record.revision)
+
+
+def _validate_review_entry_is_current(
+    entry,
+    current: AcceptedRecord | None,
+) -> None:
+    if entry.accepted is None:
+        if current is not None:
+            raise ValueError(f"Review entry {entry.occurrence_id} is stale")
+        return
+
+    if current is None:
+        raise ValueError(f"Review entry {entry.occurrence_id} is stale")
+    accepted_revision = entry.accepted.get("revision")
+    accepted_hash = entry.accepted.get("content_hash")
+    if current.revision != accepted_revision or current.content_hash != accepted_hash:
+        raise ValueError(f"Review entry {entry.occurrence_id} is stale")
+
+
+def _accepted_content_hash(payload: dict[str, object]) -> str:
+    copy = json.loads(json.dumps(payload))
+    copy["content_hash"] = ""
+    metadata = copy.get("metadata", {})
+    if isinstance(metadata, dict):
+        provenance = metadata.get(DESCRIPTION_PROVENANCE_KEY)
+        if isinstance(provenance, dict):
+            provenance["generated_at"] = ""
+        review = metadata.get(DESCRIPTION_REVIEW_KEY)
+        if isinstance(review, dict):
+            review["reviewed_at"] = ""
+    return sha256_text(json.dumps(copy, sort_keys=True))
+
+
+def _approval_change_reason(is_new: bool, resolution: str) -> str:
+    if is_new:
+        return "Accepted after review"
+    if resolution == "prose-edited":
+        return "Approved reviewed prose edits"
+    if resolution == "facts-corrected":
+        return "Approved corrected review facts"
+    return "Approved reviewed content"
+
+
+def _reviewed_at() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/astrocal/services/review_query_service.py
+++ b/src/astrocal/services/review_query_service.py
@@ -7,8 +7,16 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..jsonio import read_json
-from ..models import ReviewBundle, ReviewBundleEntry
+from ..models import (
+    AcceptedRecord,
+    DESCRIPTION_PROVENANCE_KEY,
+    DESCRIPTION_REVIEW_KEY,
+    GENERATED_CONTENT_HASH_KEY,
+    ReviewBundle,
+    ReviewBundleEntry,
+)
 from ..paths import PROJECT_ROOT
+from ..repositories import CatalogStore
 
 
 @dataclass(slots=True)
@@ -17,11 +25,39 @@ class PendingReview:
     bundle: ReviewBundle
 
 
-def list_pending_reviews(report_dir: Path | None = None) -> list[PendingReview]:
+def list_pending_reviews(
+    report_dir: Path | None = None,
+    catalog_store: CatalogStore | None = None,
+) -> list[PendingReview]:
     base_dir = _resolve_report_dir(report_dir)
+    catalog_store = catalog_store or CatalogStore()
     pending: list[PendingReview] = []
+    active_records_by_source: dict[tuple[int, str], dict[str, AcceptedRecord]] = {}
     for path in sorted(base_dir.glob("*/review.*.json")):
-        pending.append(PendingReview(report_path=path, bundle=load_review_bundle(path)))
+        bundle = load_review_bundle(path)
+        pending_entries = [
+            entry
+            for entry in bundle.entries
+            if _is_pending_entry(
+                entry=entry,
+                year=bundle.year,
+                catalog_store=catalog_store,
+                active_records_by_source=active_records_by_source,
+            )
+        ]
+        if not pending_entries:
+            continue
+        pending.append(
+            PendingReview(
+                report_path=path,
+                bundle=ReviewBundle(
+                    calendar_name=bundle.calendar_name,
+                    year=bundle.year,
+                    generated_at=bundle.generated_at,
+                    entries=pending_entries,
+                ),
+            )
+        )
     return pending
 
 
@@ -76,3 +112,78 @@ def _resolve_path(path: Path) -> Path:
     if path.is_absolute():
         return path
     return PROJECT_ROOT / path
+
+
+def _is_pending_entry(
+    *,
+    entry: ReviewBundleEntry,
+    year: int,
+    catalog_store: CatalogStore,
+    active_records_by_source: dict[tuple[int, str], dict[str, AcceptedRecord]],
+) -> bool:
+    active_by_occurrence = _active_records_for_source(
+        year=year,
+        source_name=entry.source_name,
+        catalog_store=catalog_store,
+        active_records_by_source=active_records_by_source,
+    )
+    current = active_by_occurrence.get(entry.occurrence_id)
+
+    if entry.status == "suspected-removed":
+        return _matches_entry_baseline(entry, current)
+
+    if current is None:
+        return entry.accepted is None
+    if _entry_is_satisfied(entry, current):
+        return False
+    if entry.accepted is None:
+        return True
+    return _matches_entry_baseline(entry, current)
+
+
+def _active_records_for_source(
+    *,
+    year: int,
+    source_name: str,
+    catalog_store: CatalogStore,
+    active_records_by_source: dict[tuple[int, str], dict[str, AcceptedRecord]],
+) -> dict[str, AcceptedRecord]:
+    key = (year, source_name)
+    cached = active_records_by_source.get(key)
+    if cached is not None:
+        return cached
+
+    active = {
+        record.occurrence_id: record
+        for record in catalog_store.load("astronomy", year, source_name)
+        if record.status == "active"
+    }
+    active_records_by_source[key] = active
+    return active
+
+
+def _entry_is_satisfied(entry: ReviewBundleEntry, current: AcceptedRecord) -> bool:
+    if entry.candidate is None:
+        return False
+    metadata = current.record.get("metadata", {})
+    if not isinstance(metadata, dict):
+        return False
+    review = metadata.get(DESCRIPTION_REVIEW_KEY, {})
+    if not isinstance(review, dict) or review.get("status") != "accepted":
+        return False
+    provenance = metadata.get(DESCRIPTION_PROVENANCE_KEY, {})
+    if not isinstance(provenance, dict):
+        return False
+    generated_content_hash = provenance.get(GENERATED_CONTENT_HASH_KEY)
+    return isinstance(generated_content_hash, str) and (
+        generated_content_hash == entry.generated_content_hash
+    )
+
+
+def _matches_entry_baseline(entry: ReviewBundleEntry, current: AcceptedRecord | None) -> bool:
+    if current is None or entry.accepted is None:
+        return False
+    return (
+        current.revision == entry.accepted.get("revision")
+        and current.content_hash == entry.accepted.get("content_hash")
+    )

--- a/src/astrocal/services/review_query_service.py
+++ b/src/astrocal/services/review_query_service.py
@@ -1,0 +1,77 @@
+"""Read-only helpers for persisted eclipse review bundles."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..jsonio import read_json
+from ..models import ReviewBundle, ReviewBundleEntry
+from ..paths import PROJECT_ROOT
+
+
+@dataclass(slots=True)
+class PendingReview:
+    report_path: Path
+    bundle: ReviewBundle
+
+
+def list_pending_reviews(report_dir: Path | None = None) -> list[PendingReview]:
+    base_dir = _resolve_report_dir(report_dir)
+    pending: list[PendingReview] = []
+    for path in sorted(base_dir.glob("*/review.*.json")):
+        pending.append(PendingReview(report_path=path, bundle=load_review_bundle(path)))
+    return pending
+
+
+def load_review_bundle(report_path: Path) -> ReviewBundle:
+    resolved_path = _resolve_path(report_path)
+    payload = read_json(resolved_path)
+    return ReviewBundle.from_dict(payload)
+
+
+def render_review_bundle(bundle: ReviewBundle, *, output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(bundle.to_dict(), indent=2, sort_keys=True)
+
+    lines = [
+        f"Review bundle: {bundle.calendar_name}",
+        f"Year: {bundle.year}",
+        f"Generated at: {bundle.generated_at}",
+        f"Entries: {len(bundle.entries)}",
+        "",
+    ]
+    for entry in bundle.entries:
+        lines.extend(_render_entry(entry))
+    return "\n".join(lines).rstrip()
+
+
+def _render_entry(entry: ReviewBundleEntry) -> list[str]:
+    title = ""
+    if entry.candidate is not None:
+        title = str(entry.candidate.get("title", ""))
+    elif entry.accepted is not None:
+        accepted_record = entry.accepted.get("record", {})
+        if isinstance(accepted_record, dict):
+            title = str(accepted_record.get("title", ""))
+    lines = [
+        f"- {entry.occurrence_id}",
+        f"  status={entry.status} group_id={entry.group_id}",
+    ]
+    if title:
+        lines.append(f"  title={title}")
+    lines.append(f"  allowed_actions={', '.join(entry.allowed_actions)}")
+    return lines + [""]
+
+
+def _resolve_report_dir(report_dir: Path | None) -> Path:
+    if report_dir is None:
+        return PROJECT_ROOT / "data" / "catalog" / "reports"
+    return _resolve_path(report_dir)
+
+
+def _resolve_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return PROJECT_ROOT / path

--- a/src/astrocal/services/review_query_service.py
+++ b/src/astrocal/services/review_query_service.py
@@ -57,7 +57,8 @@ def _render_entry(entry: ReviewBundleEntry) -> list[str]:
             title = str(accepted_record.get("title", ""))
     lines = [
         f"- {entry.occurrence_id}",
-        f"  status={entry.status} group_id={entry.group_id}",
+        f"  status={entry.status}",
+        f"  group_id={entry.group_id}",
     ]
     if title:
         lines.append(f"  title={title}")

--- a/src/astrocal/services/run_service.py
+++ b/src/astrocal/services/run_service.py
@@ -63,11 +63,11 @@ def run_command(args: argparse.Namespace) -> int:
         report_store=report_store,
         run_timestamp=run_timestamp,
     )
-    review_suffix = (
-        f" review_report={reconcile_report.review_report_path}"
-        if reconcile_report.review_report_path
-        else ""
-    )
+    review_suffix = ""
+    if reconcile_report.review_report_path:
+        review_suffix += f" review_report={reconcile_report.review_report_path}"
+    if reconcile_report.review_bundle_path:
+        review_suffix += f" review_bundle={reconcile_report.review_bundle_path}"
     print(
         f"reconcile {manifest.name} year={args.year} report_dir={report_dir} "
         f"new={len(reconcile_report.new_occurrences)} "

--- a/src/astrocal/services/stub_service.py
+++ b/src/astrocal/services/stub_service.py
@@ -13,6 +13,7 @@ from ..repositories import ReportStore
 from ..services.build_ics_service import build_calendar
 from ..services.fetch_service import fetch_source_family
 from ..services.normalize_service import normalize_source_family
+from ..services.review_query_service import list_pending_reviews, load_review_bundle, render_review_bundle
 from ..services.reconcile_service import reconcile_calendar
 from ..services.validation_service import validate_source_family
 
@@ -101,6 +102,22 @@ def reconcile_command(args: argparse.Namespace) -> int:
         f"{review_suffix}"
     )
     return 1 if report.validation_failures else 0
+
+
+def list_pending_reviews_command(args: argparse.Namespace) -> int:
+    pending = list_pending_reviews(args.report_dir)
+    for review in pending:
+        print(
+            f"report={review.report_path} calendar={review.bundle.calendar_name} "
+            f"year={review.bundle.year} entries={len(review.bundle.entries)}"
+        )
+    return 0
+
+
+def show_review_command(args: argparse.Namespace) -> int:
+    bundle = load_review_bundle(args.report)
+    print(render_review_bundle(bundle, output_format=args.format))
+    return 0
 
 
 def build_command(args: argparse.Namespace) -> int:

--- a/src/astrocal/services/stub_service.py
+++ b/src/astrocal/services/stub_service.py
@@ -93,9 +93,11 @@ def reconcile_command(args: argparse.Namespace) -> int:
         report_store=ReportStore(base_dir=args.report_dir) if args.report_dir else None,
     )
     report_dir = _report_dir_value(args.report_dir)
-    review_suffix = (
-        f" review_report={report.review_report_path}" if report.review_report_path else ""
-    )
+    review_suffix = ""
+    if report.review_report_path:
+        review_suffix += f" review_report={report.review_report_path}"
+    if report.review_bundle_path:
+        review_suffix += f" review_bundle={report.review_bundle_path}"
     print(
         f"reconcile {manifest.name} year={args.year} report_dir={report_dir} "
         f"new={len(report.new_occurrences)} "

--- a/src/astrocal/services/stub_service.py
+++ b/src/astrocal/services/stub_service.py
@@ -9,10 +9,11 @@ from pathlib import Path
 
 from ..adapters import ASTRONOMY_ADAPTERS
 from ..manifests import load_manifest
-from ..repositories import ReportStore
+from ..repositories import CatalogStore, ReportStore
 from ..services.build_ics_service import build_calendar
 from ..services.fetch_service import fetch_source_family
 from ..services.normalize_service import normalize_source_family
+from ..services.review_approval_service import approve_review
 from ..services.review_query_service import list_pending_reviews, load_review_bundle, render_review_bundle
 from ..services.reconcile_service import reconcile_calendar
 from ..services.validation_service import validate_source_family
@@ -117,6 +118,29 @@ def list_pending_reviews_command(args: argparse.Namespace) -> int:
 def show_review_command(args: argparse.Namespace) -> int:
     bundle = load_review_bundle(args.report)
     print(render_review_bundle(bundle, output_format=args.format))
+    return 0
+
+
+def approve_review_command(args: argparse.Namespace) -> int:
+    description = None
+    if args.description_file is not None:
+        description = args.description_file.read_text(encoding="utf-8")
+    result = approve_review(
+        report_path=args.report,
+        reviewer=args.reviewer,
+        occurrence_ids=args.occurrence_id,
+        group_ids=args.group_id,
+        resolution=args.resolution,
+        note=args.note,
+        title=args.title,
+        summary=args.summary,
+        description=description,
+        catalog_store=CatalogStore(base_dir=args.catalog_dir) if args.catalog_dir else None,
+    )
+    print(
+        f"approved count={len(result.approved_records)} "
+        f"catalog_path={result.catalog_path}"
+    )
     return 0
 
 

--- a/src/astrocal/services/stub_service.py
+++ b/src/astrocal/services/stub_service.py
@@ -108,7 +108,10 @@ def reconcile_command(args: argparse.Namespace) -> int:
 
 
 def list_pending_reviews_command(args: argparse.Namespace) -> int:
-    pending = list_pending_reviews(args.report_dir)
+    pending = list_pending_reviews(
+        args.report_dir,
+        catalog_store=CatalogStore(base_dir=args.catalog_dir) if args.catalog_dir else None,
+    )
     for review in pending:
         print(
             f"report={review.report_path} calendar={review.bundle.calendar_name} "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -231,6 +231,7 @@ def test_reconcile_command_prints_review_report_path(capsys, mocker) -> None:
                 year=2026,
                 generated_at="2026-03-01T00:00:00Z",
                 review_report_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.md",
+                review_bundle_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.json",
             ),
             [],
         ),
@@ -241,6 +242,7 @@ def test_reconcile_command_prints_review_report_path(capsys, mocker) -> None:
 
     assert exit_code == 0
     assert "review_report=data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.md" in captured.out
+    assert "review_bundle=data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.json" in captured.out
 
 
 def test_run_command_stops_before_build_when_review_is_pending(capsys, mocker) -> None:
@@ -256,6 +258,7 @@ def test_run_command_stops_before_build_when_review_is_pending(capsys, mocker) -
                 year=2026,
                 generated_at="2026-03-01T00:00:00Z",
                 review_report_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.md",
+                review_bundle_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.json",
             ),
             [],
         ),
@@ -268,6 +271,7 @@ def test_run_command_stops_before_build_when_review_is_pending(capsys, mocker) -
     assert exit_code == 0
     assert "reconcile astronomy-eclipses year=2026" in captured.out
     assert "review_report=data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.md" in captured.out
+    assert "review_bundle=data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.json" in captured.out
     assert "build astronomy-eclipses" not in captured.out
     build_mock.assert_not_called()
 
@@ -288,6 +292,7 @@ def test_run_command_for_eclipse_manifest_ignores_unrelated_source_validation(ca
                 year=2026,
                 generated_at="2026-03-01T00:00:00Z",
                 review_report_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.md",
+                review_bundle_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.json",
             ),
             [],
         ),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
+import json
+
 from astrocal.cli import main
-from astrocal.models import BuildReport, RawFetchResult, ReconciliationReport, ValidationReport
+from astrocal.models import (
+    BuildReport,
+    RawFetchResult,
+    ReconciliationReport,
+    ReviewBundle,
+    ReviewBundleEntry,
+    ValidationReport,
+)
 
 
 def build_adapter(source_name: str) -> CliAdapter:
@@ -293,3 +302,95 @@ def test_run_command_for_eclipse_manifest_ignores_unrelated_source_validation(ca
     assert "validate moon-phases start year=2026" not in captured.out
     assert "validate moon-phases status=failed" not in captured.out
     build_mock.assert_not_called()
+
+
+def test_list_pending_reviews_command_prints_persisted_review_bundles(capsys, tmp_path) -> None:
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=["approve-as-is"],
+                candidate={"title": "Total Solar Eclipse"},
+                accepted=None,
+            )
+        ],
+    )
+    report_path = tmp_path / "2026-03-03T00-00-00Z" / "review.astronomy-eclipses.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    exit_code = main(["list-pending-reviews", "--report-dir", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert f"report={report_path}" in captured.out
+    assert "calendar=astronomy-eclipses year=2026 entries=1" in captured.out
+
+
+def test_show_review_command_supports_json_output(capsys, tmp_path) -> None:
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=["approve-as-is", "approve-with-prose-edits"],
+                candidate={"title": "Total Solar Eclipse"},
+                accepted=None,
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    exit_code = main(["show-review", "--report", str(report_path), "--format", "json"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert '"calendar_name": "astronomy-eclipses"' in captured.out
+    assert '"occurrence_id": "astronomy/eclipse/2026-08-12/total-sun/full-duration"' in captured.out
+
+
+def test_show_review_command_supports_markdown_output(capsys, tmp_path) -> None:
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="changed",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=["approve-as-is", "approve-with-prose-edits"],
+                candidate={"title": "Total Solar Eclipse"},
+                accepted={"record": {"title": "Previous Eclipse Title"}},
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    exit_code = main(["show-review", "--report", str(report_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Review bundle: astronomy-eclipses" in captured.out
+    assert "status=changed group_id=astronomy/eclipse/2026-08-12/total-sun" in captured.out
+    assert "title=Total Solar Eclipse" in captured.out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -394,3 +394,92 @@ def test_show_review_command_supports_markdown_output(capsys, tmp_path) -> None:
     assert "Review bundle: astronomy-eclipses" in captured.out
     assert "status=changed group_id=astronomy/eclipse/2026-08-12/total-sun" in captured.out
     assert "title=Total Solar Eclipse" in captured.out
+
+
+def test_approve_review_command_writes_accepted_revision(capsys, tmp_path) -> None:
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=["approve-as-is", "approve-with-prose-edits"],
+                candidate={
+                    "accepted_revision": None,
+                    "all_day": False,
+                    "body": "sun",
+                    "candidate_status": "new",
+                    "categories": ["Astronomy", "Eclipse"],
+                    "content_hash": "sha256:candidate",
+                    "description": "Generated eclipse description.",
+                    "detail_url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+                    "end": "2026-08-12T19:57:57Z",
+                    "event_type": "eclipse",
+                    "first_seen_at": "2026-03-03T00:00:00Z",
+                    "group_id": "astronomy/eclipse/2026-08-12/total-sun",
+                    "is_default": True,
+                    "last_seen_at": "2026-03-03T00:00:00Z",
+                    "metadata": {
+                        "description_provenance": {
+                            "facts_hash": "sha256:facts",
+                            "facts_schema_version": "eclipse-facts-v1",
+                            "generator": "test-generator",
+                            "generated_at": "2026-03-03T00:00:00Z",
+                            "prompt_version": "eclipse-description-v1",
+                        }
+                    },
+                    "occurrence_id": "astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                    "raw_ref": "data/raw/astronomy/2026/timeanddate-eclipses/eclipse-2.html",
+                    "source_adapter": "timeanddate-eclipse-v1",
+                    "source_type": "astronomy",
+                    "source_validation": {
+                        "checks": ["reachable"],
+                        "detail_url_ok": True,
+                        "reason": None,
+                        "status": "passed",
+                        "validated_at": "2026-03-03T00:00:00Z",
+                    },
+                    "start": "2026-08-12T15:34:15Z",
+                    "summary": "Total Solar Eclipse",
+                    "tags": ["eclipse", "sun", "total"],
+                    "timezone": "UTC",
+                    "timing_source": {
+                        "name": "timeanddate",
+                        "url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+                    },
+                    "title": "Total Solar Eclipse",
+                    "validation_sources": [],
+                    "variant": "full-duration",
+                },
+                accepted=None,
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "approve-review",
+            "--report",
+            str(report_path),
+            "--reviewer",
+            "tester",
+            "--occurrence-id",
+            "astronomy/eclipse/2026-08-12/total-sun/full-duration",
+            "--catalog-dir",
+            str(tmp_path / "accepted"),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "approved count=1" in captured.out
+    saved_path = tmp_path / "accepted" / "astronomy" / "2026" / "eclipses.json"
+    assert saved_path.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -397,7 +397,8 @@ def test_show_review_command_supports_markdown_output(capsys, tmp_path) -> None:
 
     assert exit_code == 0
     assert "Review bundle: astronomy-eclipses" in captured.out
-    assert "status=changed group_id=astronomy/eclipse/2026-08-12/total-sun" in captured.out
+    assert "status=changed" in captured.out
+    assert "group_id=astronomy/eclipse/2026-08-12/total-sun" in captured.out
     assert "title=Total Solar Eclipse" in captured.out
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import json
 
 from astrocal.cli import main
 from astrocal.models import (
+    AcceptedRecord,
     BuildReport,
     RawFetchResult,
     ReconciliationReport,
@@ -11,6 +12,7 @@ from astrocal.models import (
     ReviewBundleEntry,
     ValidationReport,
 )
+from astrocal.repositories import CatalogStore
 
 
 def build_adapter(source_name: str) -> CliAdapter:
@@ -338,6 +340,122 @@ def test_list_pending_reviews_command_prints_persisted_review_bundles(capsys, tm
     assert exit_code == 0
     assert f"report={report_path}" in captured.out
     assert "calendar=astronomy-eclipses year=2026 entries=1" in captured.out
+
+
+def test_list_pending_reviews_command_omits_already_approved_bundle(capsys, tmp_path) -> None:
+    candidate = {
+        "accepted_revision": None,
+        "all_day": False,
+        "body": "sun",
+        "candidate_status": "new",
+        "categories": ["Astronomy", "Eclipse"],
+        "content_hash": "sha256:candidate",
+        "description": "Generated eclipse description.",
+        "detail_url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+        "end": "2026-08-12T19:57:57Z",
+        "event_type": "eclipse",
+        "first_seen_at": "2026-03-03T00:00:00Z",
+        "group_id": "astronomy/eclipse/2026-08-12/total-sun",
+        "is_default": True,
+        "last_seen_at": "2026-03-03T00:00:00Z",
+        "metadata": {
+            "description_provenance": {
+                "facts_hash": "sha256:facts",
+                "facts_schema_version": "eclipse-facts-v1",
+                "generator": "test-generator",
+                "generated_at": "2026-03-03T00:00:00Z",
+                "prompt_version": "eclipse-description-v1",
+                "generated_content_hash": "sha256:candidate",
+            },
+            "description_review": {
+                "status": "accepted",
+                "reviewed_at": "2026-03-03T01:00:00Z",
+                "reviewer": "tester",
+                "edited": False,
+                "resolution": "accepted",
+                "note": None,
+            },
+        },
+        "occurrence_id": "astronomy/eclipse/2026-08-12/total-sun/full-duration",
+        "raw_ref": "data/raw/astronomy/2026/timeanddate-eclipses/eclipse-2.html",
+        "source_adapter": "timeanddate-eclipse-v1",
+        "source_type": "astronomy",
+        "source_validation": {
+            "checks": ["reachable"],
+            "detail_url_ok": True,
+            "reason": None,
+            "status": "passed",
+            "validated_at": "2026-03-03T00:00:00Z",
+        },
+        "start": "2026-08-12T15:34:15Z",
+        "summary": "Total Solar Eclipse",
+        "tags": ["eclipse", "sun", "total"],
+        "timezone": "UTC",
+        "timing_source": {
+            "name": "timeanddate",
+            "url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+        },
+        "title": "Total Solar Eclipse",
+        "validation_sources": [],
+        "variant": "full-duration",
+    }
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=["approve-as-is"],
+                candidate=candidate,
+                accepted=None,
+            )
+        ],
+    )
+    report_path = tmp_path / "2026-03-03T00-00-00Z" / "review.astronomy-eclipses.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    accepted_dir = tmp_path / "accepted"
+    accepted_store = CatalogStore(base_dir=accepted_dir)
+    accepted_store.save(
+        "astronomy",
+        2026,
+        "eclipses",
+        [
+            AcceptedRecord(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                revision=1,
+                status="active",
+                accepted_at="2026-03-03T01:00:00Z",
+                superseded_at=None,
+                change_reason="Accepted after review",
+                content_hash="sha256:approved",
+                source_adapter="timeanddate-eclipse-v1",
+                detail_url="https://www.timeanddate.com/eclipse/solar/2026-august-12",
+                record=candidate | {"accepted_revision": 1, "candidate_status": "accepted", "content_hash": "sha256:approved"},
+            )
+        ],
+    )
+
+    exit_code = main(
+        [
+            "list-pending-reviews",
+            "--report-dir",
+            str(tmp_path),
+            "--catalog-dir",
+            str(accepted_dir),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == ""
 
 
 def test_show_review_command_supports_json_output(capsys, tmp_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -488,3 +488,43 @@ def test_approve_review_command_writes_accepted_revision(capsys, tmp_path) -> No
     assert "approved count=1" in captured.out
     saved_path = tmp_path / "accepted" / "astronomy" / "2026" / "eclipses.json"
     assert saved_path.exists()
+
+
+def test_approve_review_command_reports_expected_errors_without_traceback(capsys, tmp_path) -> None:
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-03-03/total-moon/full-duration",
+                group_id="astronomy/eclipse/2026-03-03/total-moon",
+                status="suspected-removed",
+                source_name="eclipses",
+                candidate_content_hash=None,
+                generated_content_hash="sha256:accepted",
+                allowed_actions=["review-removal"],
+                candidate=None,
+                accepted={"revision": 1, "content_hash": "sha256:accepted"},
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    exit_code = main(
+        [
+            "approve-review",
+            "--report",
+            str(report_path),
+            "--reviewer",
+            "tester",
+            "--occurrence-id",
+            "astronomy/eclipse/2026-03-03/total-moon/full-duration",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "suspected removal" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_reconcile_service.py
+++ b/tests/test_reconcile_service.py
@@ -295,6 +295,84 @@ def test_reconcile_eclipse_manifest_does_not_touch_unrelated_sources(tmp_path: P
     assert saved[0].status == "active"
 
 
+def test_reconcile_treats_approved_prose_edit_as_unchanged(tmp_path: Path) -> None:
+    candidate_store = CandidateStore(base_dir=tmp_path / "normalized")
+    catalog_store = CatalogStore(base_dir=tmp_path / "accepted")
+    report_store = ReportStore(base_dir=tmp_path / "reports")
+    eclipse = build_candidate()
+    eclipse.group_id = "astronomy/eclipse/2026-08-12/total-sun"
+    eclipse.occurrence_id = "astronomy/eclipse/2026-08-12/total-sun/full-duration"
+    eclipse.body = "sun"
+    eclipse.event_type = "eclipse"
+    eclipse.variant = "full-duration"
+    eclipse.title = "Total Solar Eclipse"
+    eclipse.summary = "Total Solar Eclipse"
+    eclipse.description = "Generated eclipse description."
+    eclipse.start = "2026-08-12T15:34:15Z"
+    eclipse.end = "2026-08-12T19:57:57Z"
+    eclipse.detail_url = "https://www.timeanddate.com/eclipse/solar/2026-august-12"
+    eclipse.content_hash = "sha256:generated"
+    eclipse.metadata = {
+        "description_provenance": {
+            "facts_hash": "sha256:facts",
+            "facts_schema_version": "eclipse-facts-v1",
+            "generator": "test-generator",
+            "generated_at": "2026-03-02T00:00:00Z",
+            "prompt_version": "eclipse-description-v1",
+        }
+    }
+    candidate_store.save("astronomy", 2026, "eclipses", [eclipse])
+
+    accepted = _accepted_from_candidate(
+        eclipse,
+        revision=1,
+        status="active",
+        accepted_at="2026-03-02T12:00:00Z",
+        change_reason="Accepted after review",
+    )
+    accepted.record["title"] = "Edited Eclipse Title"
+    accepted.record["summary"] = "Edited Eclipse Summary"
+    accepted.record["description"] = "Edited eclipse description."
+    accepted.record["content_hash"] = "sha256:edited"
+    accepted.content_hash = "sha256:edited"
+    accepted.record["accepted_revision"] = 1
+    accepted.record["candidate_status"] = "accepted"
+    accepted.record["metadata"]["description_provenance"] = {
+        "facts_hash": "sha256:facts",
+        "facts_schema_version": "eclipse-facts-v1",
+        "generator": "test-generator",
+        "generated_at": "2026-03-02T00:00:00Z",
+        "prompt_version": "eclipse-description-v1",
+        "generated_content_hash": "sha256:generated",
+    }
+    accepted.record["metadata"]["description_review"] = {
+        "status": "accepted",
+        "reviewed_at": "2026-03-02T13:00:00Z",
+        "reviewer": "tester",
+        "edited": True,
+        "resolution": "prose-edited",
+        "note": "Tightened wording.",
+    }
+    catalog_store.save("astronomy", 2026, "eclipses", [accepted])
+
+    report, written_paths = reconcile_calendar(
+        manifest=build_eclipse_manifest(),
+        year=2026,
+        candidate_store=candidate_store,
+        catalog_store=catalog_store,
+        report_store=report_store,
+        run_timestamp="2026-03-03T12-00-00Z",
+    )
+
+    saved = catalog_store.load("astronomy", 2026, "eclipses")
+    assert report.unchanged_occurrences == [eclipse.occurrence_id]
+    assert report.review_report_path is None
+    assert report.review_bundle_path is None
+    assert len(saved) == 1
+    assert saved[0].record["title"] == "Edited Eclipse Title"
+    assert all("review.astronomy-eclipses" not in path.name for path in written_paths)
+
+
 def test_reconcile_writes_catalog_and_reports_without_staging(tmp_path: Path) -> None:
     candidate_store = CandidateStore(base_dir=tmp_path / "normalized")
     catalog_store = CatalogStore(base_dir=tmp_path / "accepted")

--- a/tests/test_reconcile_service.py
+++ b/tests/test_reconcile_service.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from astrocal.models import CalendarManifest
+from astrocal.models import CalendarManifest, ReviewBundle
 from astrocal.repositories import CandidateStore, CatalogStore, ReportStore
 from astrocal.services.reconcile_service import reconcile_calendar
 from tests.test_repositories import build_candidate
@@ -226,9 +227,22 @@ def test_reconcile_eclipse_changes_write_review_report_without_updating_catalog(
 
     assert report.new_occurrences == [eclipse.occurrence_id]
     assert report.review_report_path is not None
+    assert report.review_bundle_path is not None
     assert catalog_store.load("astronomy", 2026, "eclipses") == []
+    assert any(path.name == "review.astronomy-eclipses.json" for path in written_paths)
     assert any(path.name == "review.astronomy-eclipses.md" for path in written_paths)
     assert any(path.name == "reconcile.astronomy-eclipses.json" for path in written_paths)
+    review_bundle_path = next(path for path in written_paths if path.name == "review.astronomy-eclipses.json")
+    review_bundle = ReviewBundle.from_dict(json.loads(review_bundle_path.read_text(encoding="utf-8")))
+    assert review_bundle.calendar_name == "astronomy-eclipses"
+    assert review_bundle.entries[0].status == "new"
+    assert review_bundle.entries[0].allowed_actions == [
+        "approve-as-is",
+        "approve-with-prose-edits",
+        "approve-with-fact-corrections",
+    ]
+    assert review_bundle.entries[0].candidate is not None
+    assert review_bundle.entries[0].candidate["title"] == "Total Solar Eclipse"
     review_path = next(path for path in written_paths if path.name == "review.astronomy-eclipses.md")
     review_text = review_path.read_text(encoding="utf-8")
     assert "Generated eclipse description." in review_text

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -4,6 +4,8 @@ from astrocal.models import (
     AcceptedRecord,
     CandidateRecord,
     ReconciliationReport,
+    ReviewBundle,
+    ReviewBundleEntry,
     SourceReference,
     ValidationResult,
 )
@@ -132,11 +134,51 @@ def test_reconciliation_report_supports_review_artifacts() -> None:
         year=2026,
         generated_at="2026-03-01T00-00-00Z",
         review_report_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.md",
+        review_bundle_path="data/catalog/reports/2026-03-01T00-00-00Z/review.astronomy-eclipses.json",
     )
 
     payload = report.to_dict()
 
     assert payload["review_report_path"].endswith("review.astronomy-eclipses.md")
+    assert payload["review_bundle_path"].endswith("review.astronomy-eclipses.json")
+
+
+def test_review_bundle_round_trip() -> None:
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-01T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=[
+                    "approve-as-is",
+                    "approve-with-prose-edits",
+                    "approve-with-fact-corrections",
+                ],
+                candidate={"title": "Total Solar Eclipse"},
+                accepted=None,
+            )
+        ],
+    )
+
+    payload = bundle.to_dict()
+    loaded = ReviewBundle.from_dict(payload)
+
+    assert loaded.calendar_name == "astronomy-eclipses"
+    assert len(loaded.entries) == 1
+    assert loaded.entries[0].allowed_actions == [
+        "approve-as-is",
+        "approve-with-prose-edits",
+        "approve-with-fact-corrections",
+    ]
+    assert loaded.entries[0].candidate is not None
+    assert loaded.entries[0].candidate["title"] == "Total Solar Eclipse"
 
 
 def test_sequence_store_round_trip(tmp_path) -> None:

--- a/tests/test_review_approval_service.py
+++ b/tests/test_review_approval_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from astrocal.models import GENERATED_CONTENT_HASH_KEY, ReviewBundle, ReviewBundleEntry
+from astrocal.repositories import CatalogStore
+from astrocal.services.review_approval_service import approve_review
+from tests.test_reconcile_service import _accepted_from_candidate
+from tests.test_review_report_service import build_eclipse_candidate
+
+
+def test_approve_review_creates_initial_accepted_revision(tmp_path) -> None:
+    candidate = build_eclipse_candidate()
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id=candidate.occurrence_id,
+                group_id=candidate.group_id,
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash=candidate.content_hash,
+                generated_content_hash=candidate.content_hash,
+                allowed_actions=["approve-as-is"],
+                candidate=candidate.to_dict(),
+                accepted=None,
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    result = approve_review(
+        report_path=report_path,
+        reviewer="tester",
+        occurrence_ids=[candidate.occurrence_id],
+        catalog_store=CatalogStore(base_dir=tmp_path / "accepted"),
+        reviewed_at="2026-03-03T01:00:00Z",
+    )
+
+    saved = CatalogStore(base_dir=tmp_path / "accepted").load("astronomy", 2026, "eclipses")
+    assert result.catalog_path.exists()
+    assert len(saved) == 1
+    assert saved[0].revision == 1
+    assert saved[0].record["metadata"]["description_review"]["status"] == "accepted"
+    assert (
+        saved[0].record["metadata"]["description_provenance"][GENERATED_CONTENT_HASH_KEY]
+        == candidate.content_hash
+    )
+
+
+def test_approve_review_supersedes_current_revision_when_editing_prose(tmp_path) -> None:
+    candidate = build_eclipse_candidate()
+    existing = _accepted_from_candidate(
+        candidate,
+        revision=1,
+        status="active",
+        accepted_at="2026-03-01T00:00:00Z",
+        change_reason="Initial acceptance",
+    )
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id=candidate.occurrence_id,
+                group_id=candidate.group_id,
+                status="changed",
+                source_name="eclipses",
+                candidate_content_hash=candidate.content_hash,
+                generated_content_hash=candidate.content_hash,
+                allowed_actions=["approve-as-is", "approve-with-prose-edits"],
+                candidate=candidate.to_dict(),
+                accepted=existing.to_dict(),
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    store = CatalogStore(base_dir=tmp_path / "accepted")
+    store.save("astronomy", 2026, "eclipses", [existing])
+
+    approve_review(
+        report_path=report_path,
+        reviewer="tester",
+        occurrence_ids=[candidate.occurrence_id],
+        resolution="prose-edited",
+        title="Edited Eclipse Title",
+        summary="Edited Eclipse Summary",
+        description="Edited eclipse description.",
+        note="Tightened the prose.",
+        catalog_store=store,
+        reviewed_at="2026-03-03T01:00:00Z",
+    )
+
+    saved = store.load("astronomy", 2026, "eclipses")
+    assert len(saved) == 2
+    assert saved[0].status == "superseded"
+    assert saved[1].revision == 2
+    assert saved[1].record["title"] == "Edited Eclipse Title"
+    assert saved[1].record["summary"] == "Edited Eclipse Summary"
+    assert saved[1].record["description"] == "Edited eclipse description."
+    assert saved[1].record["metadata"]["description_review"]["edited"] is True
+    assert saved[1].record["metadata"]["description_review"]["resolution"] == "prose-edited"
+    assert saved[1].record["content_hash"] == saved[1].content_hash
+    assert saved[1].content_hash != candidate.content_hash
+
+
+def test_approve_review_rejects_stale_review_entry(tmp_path) -> None:
+    candidate = build_eclipse_candidate()
+    existing = _accepted_from_candidate(
+        candidate,
+        revision=1,
+        status="active",
+        accepted_at="2026-03-01T00:00:00Z",
+        change_reason="Initial acceptance",
+    )
+    stale = _accepted_from_candidate(
+        candidate,
+        revision=1,
+        status="active",
+        accepted_at="2026-03-01T00:00:00Z",
+        change_reason="Initial acceptance",
+    )
+    stale.content_hash = "sha256:stale"
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id=candidate.occurrence_id,
+                group_id=candidate.group_id,
+                status="changed",
+                source_name="eclipses",
+                candidate_content_hash=candidate.content_hash,
+                generated_content_hash=candidate.content_hash,
+                allowed_actions=["approve-as-is"],
+                candidate=candidate.to_dict(),
+                accepted=stale.to_dict(),
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    store = CatalogStore(base_dir=tmp_path / "accepted")
+    store.save("astronomy", 2026, "eclipses", [existing])
+
+    with pytest.raises(ValueError, match="stale"):
+        approve_review(
+            report_path=report_path,
+            reviewer="tester",
+            occurrence_ids=[candidate.occurrence_id],
+            catalog_store=store,
+            reviewed_at="2026-03-03T01:00:00Z",
+        )

--- a/tests/test_review_approval_service.py
+++ b/tests/test_review_approval_service.py
@@ -159,3 +159,43 @@ def test_approve_review_rejects_stale_review_entry(tmp_path) -> None:
             catalog_store=store,
             reviewed_at="2026-03-03T01:00:00Z",
         )
+
+
+def test_approve_review_rejects_suspected_removal_entries(tmp_path) -> None:
+    candidate = build_eclipse_candidate()
+    accepted = _accepted_from_candidate(
+        candidate,
+        revision=1,
+        status="suspected-removed",
+        accepted_at="2026-03-01T00:00:00Z",
+        change_reason="Missing from current candidate set",
+    )
+    bundle = ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id=candidate.occurrence_id,
+                group_id=candidate.group_id,
+                status="suspected-removed",
+                source_name="eclipses",
+                candidate_content_hash=None,
+                generated_content_hash=candidate.content_hash,
+                allowed_actions=["review-removal"],
+                candidate=None,
+                accepted=accepted.to_dict(),
+            )
+        ],
+    )
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="suspected removal"):
+        approve_review(
+            report_path=report_path,
+            reviewer="tester",
+            occurrence_ids=[candidate.occurrence_id],
+            catalog_store=CatalogStore(base_dir=tmp_path / "accepted"),
+            reviewed_at="2026-03-03T01:00:00Z",
+        )

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -5,8 +5,9 @@ from pathlib import Path
 import pytest
 from icalendar import Calendar
 
-from astrocal.models import AcceptedRecord, CalendarManifest, RawFetchResult, ValidationReport
+from astrocal.models import CalendarManifest, RawFetchResult, ValidationReport
 from astrocal.repositories import CandidateStore, CatalogStore, DiagnosticStore, ReportStore, SequenceStore
+from astrocal.services.review_approval_service import approve_review
 from astrocal.services.build_ics_service import build_calendar
 from astrocal.services.fetch_service import fetch_source_family
 from astrocal.services.normalize_service import normalize_source_family
@@ -318,35 +319,18 @@ def test_eclipse_review_flow_requires_manual_acceptance_before_build(tmp_path) -
     )
 
     assert reconcile_report.review_report_path is not None
+    assert reconcile_report.review_bundle_path is not None
+    assert any(path.name == "review.astronomy-eclipses.json" for path in written_paths)
     assert any(path.name == "review.astronomy-eclipses.md" for path in written_paths)
     assert catalog_store.load("astronomy", 2026, "eclipses") == []
 
-    accepted_records = []
-    for candidate in candidates:
-        accepted_candidate = candidate.to_dict()
-        accepted_candidate["metadata"]["description_review"] = {
-            "status": "accepted",
-            "reviewed_at": "2026-03-02T13:00:00Z",
-            "reviewer": "tester",
-            "edited": False,
-            "resolution": "accepted",
-            "note": "Accepted generated copy.",
-        }
-        accepted_records.append(
-            AcceptedRecord(
-                occurrence_id=candidate.occurrence_id,
-                revision=1,
-                status="active",
-                accepted_at="2026-03-02T13:00:00Z",
-                superseded_at=None,
-                change_reason="Accepted after review",
-                content_hash=candidate.content_hash,
-                source_adapter=candidate.source_adapter,
-                detail_url=candidate.detail_url,
-                record=accepted_candidate,
-            )
-        )
-    catalog_store.save("astronomy", 2026, "eclipses", accepted_records)
+    approve_review(
+        report_path=Path(reconcile_report.review_bundle_path),
+        reviewer="tester",
+        group_ids=sorted({candidate.group_id for candidate in candidates}),
+        catalog_store=catalog_store,
+        reviewed_at="2026-03-02T13:00:00Z",
+    )
 
     build_report, _ = build_calendar(
         manifest=manifest,


### PR DESCRIPTION
## Summary
- add persisted JSON review bundles for eclipse reconcile runs
- add minimal review CLI commands for listing, inspecting, and approving review bundles
- promote approved eclipse content through a dedicated approval service instead of manual accepted-catalog JSON edits
- document the Issue #20 implementation plan and updated review workflow

## Related
- Closes #20
- Follow-on local MCP server work is tracked in #22
- Follow-on graceful CLI user-error handling is tracked in #23

## Testing
- `./.venv/bin/pytest -q`
- manual smoke test of `normalize`, `reconcile`, `show-review`, `approve-review`, and `build` for `astronomy-eclipses`

## Notes
- This PR stops at the service plus minimal human CLI boundary.
- The MCP layer is intentionally deferred so it can wrap the settled workflow surface rather than co-evolve with it in the same PR.