### PR TITLE
Handle expected CLI user errors gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ make install
 
 ## Maintainer Notes
 
+Expected operator mistakes in `astrocal` should return a short `error: ...` message and
+exit non-zero. Unexpected programming failures should still raise visibly, and review
+bundle errors should name the artifact path that needs attention.
+
 For source-boundary failures, use
 [`skills/debug-source-adapters/SKILL.md`](skills/debug-source-adapters/SKILL.md) to inspect
 reports, diagnostics, raw snapshots, normalized candidates, and reconciliation artifacts in

--- a/docs/plans/2026-03-03-issue-23-cli-user-errors.md
+++ b/docs/plans/2026-03-03-issue-23-cli-user-errors.md
@@ -1,0 +1,238 @@
+# Issue 23 Graceful CLI User Errors Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make expected `astrocal` operator mistakes fail with short, actionable CLI errors and exit code `1`, while still allowing genuine programming failures to surface with a traceback.
+
+**Architecture:** Introduce a dedicated `CliUserError` type for expected human-operator mistakes, then narrow the CLI boundary so `main()` catches only that type instead of every `ValueError`. Convert the current operator-facing validation paths to raise `CliUserError`, and wrap file/report parsing errors at the review workflow boundary so commands such as `build`, `run`, `reconcile`, `show-review`, `list-pending-reviews`, and `approve-review` all report the same `error: ...` shape without swallowing unexpected internal bugs.
+
+**Tech Stack:** Python 3, argparse CLI, pathlib, JSON parsing, existing `astrocal` services, pytest.
+
+---
+
+## Implementation Decisions
+
+- Use a dedicated exception for operator mistakes:
+  - create `astrocal.errors.CliUserError`
+  - keep it as a `ValueError` subclass so existing service-level tests and call sites do not need broad rewrites
+- Narrow the CLI catch in [`src/astrocal/cli.py`](/Users/andrew/Documents/Git/GitHub/andrewdmontgomery/Calendars/src/astrocal/cli.py):
+  - catch `CliUserError`
+  - stop catching all `ValueError`
+  - let uncategorized exceptions keep their traceback for debugging
+- Convert known operator-facing validations to `CliUserError` instead of plain `ValueError`:
+  - unknown manifest names
+  - invalid review approval selections and stale review entries
+  - missing or malformed persisted review bundles
+  - missing or unreadable `--description-file` inputs
+- Fail fast on corrupted persisted review artifacts.
+  - `list-pending-reviews` should not silently skip malformed review bundles
+  - the error should name the offending file path
+- Keep `argparse` usage handling unchanged.
+  - parser-level mistakes such as missing required flags already produce clean CLI output
+- Use `@python-testing-patterns` to keep the CLI regression matrix table-driven instead of duplicating one test per command and failure mode.
+- Use `@python-design-patterns` to keep exception translation near the CLI/review boundary instead of scattering generic `except Exception` blocks throughout the codebase.
+
+## Expected Error Contract
+
+- Unknown manifest:
+  - `error: Unknown calendar manifest: astronomy-does-not-exist`
+- Missing review bundle:
+  - `error: Review bundle not found: /tmp/.../review.astronomy-eclipses.json`
+- Invalid JSON review bundle:
+  - `error: Review bundle is not valid JSON: /tmp/.../review.astronomy-eclipses.json`
+- Malformed review bundle payload:
+  - `error: Review bundle is malformed: missing 'calendar_name' in /tmp/.../review.astronomy-eclipses.json`
+- Missing prose file:
+  - `error: Description file not found: /tmp/.../edited-description.md`
+
+## Recommended Commit Story
+
+1. `test: pin cli operator error contract`
+2. `feat: add explicit astrocal cli user errors`
+3. `feat: normalize review bundle and file path errors`
+4. `docs: note astrocal cli error policy`
+
+### Task 1: Pin The CLI Error Contract
+
+**Files:**
+- Modify: `tests/test_cli.py`
+
+**Step 1: Write the failing tests**
+
+Add a small table-driven CLI regression block that covers:
+- `build --calendar astronomy-does-not-exist`
+- `reconcile --calendar astronomy-does-not-exist --year 2026`
+- `run --calendar astronomy-does-not-exist --year 2026`
+- `show-review --report <missing path>`
+- `approve-review --report <missing path> --reviewer tester --occurrence-id <id>`
+- `show-review --report <invalid json file>`
+- `list-pending-reviews --report-dir <dir containing malformed bundle>`
+- `approve-review --description-file <missing path>` with an otherwise valid bundle
+
+For each case, assert:
+- `exit_code == 1` when `main(...)` returns normally
+- `captured.err` contains a short `error:` message
+- `captured.err` does not contain `Traceback`
+
+For the malformed-bundle case, create two fixtures:
+- syntactically invalid JSON
+- valid JSON missing required keys such as `calendar_name`
+
+**Step 2: Run the focused tests**
+
+Run: `pytest tests/test_cli.py -k "manifest or review or description_file" -v`
+Expected: FAIL because `FileNotFoundError`, `JSONDecodeError`, and malformed review payload errors still escape the CLI boundary.
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_cli.py
+git commit -m "test: pin cli operator error contract"
+```
+
+### Task 2: Introduce An Explicit User-Error Boundary
+
+**Files:**
+- Create: `src/astrocal/errors.py`
+- Modify: `src/astrocal/cli.py`
+- Modify: `src/astrocal/manifests.py`
+- Modify: `src/astrocal/services/review_approval_service.py`
+
+**Step 1: Write the minimal implementation**
+
+Add a dedicated exception and narrow the catch:
+
+```python
+class CliUserError(ValueError):
+    """Expected operator-facing CLI error."""
+```
+
+Update `main()` to catch only `CliUserError`:
+
+```python
+try:
+    return int(args.handler(args))
+except CliUserError as exc:
+    print(f"error: {exc}", file=sys.stderr)
+    return 1
+```
+
+Change manifest lookup to raise `CliUserError`:
+
+```python
+if not manifest_path.exists():
+    raise CliUserError(f"Unknown calendar manifest: {name}")
+```
+
+Convert the existing operator-facing approval validation paths in
+`src/astrocal/services/review_approval_service.py` from `ValueError` to `CliUserError`, including:
+- unsupported review resolution
+- missing occurrence/group selectors
+- no matching entries
+- prose override misuse
+- suspected-removal approval attempts
+- missing candidate payload
+- multi-source approval attempts
+- stale review entries
+
+Do not add a broad `except Exception` anywhere in this task.
+
+**Step 2: Run the focused tests again**
+
+Run: `pytest tests/test_cli.py -k "unknown_calendar_manifest or approve_review_command_reports_expected_errors_without_traceback" -v`
+Expected: PASS for unknown-manifest cases and the existing approve-review validation case. Review bundle file-path cases should still fail until Task 3.
+
+**Step 3: Commit**
+
+```bash
+git add src/astrocal/errors.py src/astrocal/cli.py src/astrocal/manifests.py src/astrocal/services/review_approval_service.py
+git commit -m "feat: add explicit astrocal cli user errors"
+```
+
+### Task 3: Normalize Review Bundle And File Path Failures
+
+**Files:**
+- Modify: `src/astrocal/services/review_query_service.py`
+- Modify: `src/astrocal/services/stub_service.py`
+- Modify: `tests/test_cli.py`
+
+**Step 1: Write the minimal implementation**
+
+Wrap expected persisted-artifact failures in `src/astrocal/services/review_query_service.py`:
+- `FileNotFoundError` -> `CliUserError("Review bundle not found: ...")`
+- `json.JSONDecodeError` -> `CliUserError("Review bundle is not valid JSON: ...")`
+- `KeyError`, `TypeError`, `ValueError` raised while materializing `ReviewBundle.from_dict(...)`
+  -> `CliUserError("Review bundle is malformed: ... in ...")`
+
+Keep the conversion localized to bundle loading so:
+- `show-review`
+- `list-pending-reviews`
+- `approve-review`
+
+all get the same behavior through shared code.
+
+In `src/astrocal/services/stub_service.py`, add a tiny helper for `--description-file` reads:
+
+```python
+def _read_description_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise CliUserError(f"Description file not found: {path}") from exc
+```
+
+Also handle `IsADirectoryError`, `PermissionError`, and `UnicodeDecodeError` with similarly specific messages instead of letting raw OS exceptions leak.
+
+When building malformed-bundle messages, include:
+- the report path
+- the missing field name when available
+
+Examples:
+- `Review bundle is malformed: missing 'calendar_name' in /tmp/...`
+- `Review bundle is malformed: invalid year in /tmp/...`
+
+**Step 2: Run the focused tests again**
+
+Run: `pytest tests/test_cli.py -k "review or description_file" -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add src/astrocal/services/review_query_service.py src/astrocal/services/stub_service.py tests/test_cli.py
+git commit -m "feat: normalize review bundle and file path errors"
+```
+
+### Task 4: Document The Policy And Run The Regression Sweep
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/plans/2026-03-03-issue-23-cli-user-errors.md`
+
+**Step 1: Add a short maintainer note**
+
+Document the policy in `README.md` near Local Usage or Maintainer Notes:
+- expected operator mistakes return `error: ...` and exit non-zero
+- unexpected programming failures are still allowed to raise visibly for debugging
+- persisted review bundle problems should be fixed at the artifact path named in the error
+
+Keep this note short. Do not document every exact message string.
+
+**Step 2: Run the regression sweep**
+
+Run: `pytest tests/test_cli.py tests/test_review_approval_service.py tests/test_manifests.py -v`
+Expected: PASS
+
+Run: `pytest -v`
+Expected: PASS
+
+If a broader suite failure reveals another expected operator mistake, either:
+- convert that path to `CliUserError` if it is a genuine human-operator error, or
+- leave it as a traceback if it is an internal programming/configuration defect
+
+**Step 3: Commit**
+
+```bash
+git add README.md docs/plans/2026-03-03-issue-23-cli-user-errors.md
+git commit -m "docs: note astrocal cli error policy"
+```

--- a/src/astrocal/cli.py
+++ b/src/astrocal/cli.py
@@ -6,6 +6,7 @@ import argparse
 import sys
 from pathlib import Path
 
+from .errors import CliUserError
 from .services.run_service import run_command
 from .services.stub_service import (
     approve_review_command,
@@ -94,6 +95,6 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         return int(args.handler(args))
-    except ValueError as exc:
+    except CliUserError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1

--- a/src/astrocal/errors.py
+++ b/src/astrocal/errors.py
@@ -1,0 +1,7 @@
+"""CLI-facing error types."""
+
+from __future__ import annotations
+
+
+class CliUserError(ValueError):
+    """Expected operator-facing CLI error."""

--- a/src/astrocal/manifests.py
+++ b/src/astrocal/manifests.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import tomllib
 
+from .errors import CliUserError
 from .models import CalendarManifest
 
 
@@ -16,7 +17,7 @@ MANIFEST_DIR = PROJECT_ROOT / "config" / "calendars"
 def load_manifest(name: str) -> CalendarManifest:
     manifest_path = MANIFEST_DIR / f"{name}.toml"
     if not manifest_path.exists():
-        raise FileNotFoundError(f"Unknown calendar manifest: {name}")
+        raise CliUserError(f"Unknown calendar manifest: {name}")
 
     with manifest_path.open("rb") as handle:
         data = tomllib.load(handle)

--- a/src/astrocal/services/review_approval_service.py
+++ b/src/astrocal/services/review_approval_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
+from ..errors import CliUserError
 from ..hashing import sha256_text
 from ..models import (
     AcceptedRecord,
@@ -42,12 +43,12 @@ def approve_review(
     reviewed_at: str | None = None,
 ) -> ApprovalResult:
     if resolution not in REVIEW_RESOLUTIONS:
-        raise ValueError(f"Unsupported review resolution: {resolution}")
+        raise CliUserError(f"Unsupported review resolution: {resolution}")
 
     occurrence_ids = occurrence_ids or []
     group_ids = group_ids or []
     if not occurrence_ids and not group_ids:
-        raise ValueError("Specify at least one occurrence ID or group ID to approve")
+        raise CliUserError("Specify at least one occurrence ID or group ID to approve")
 
     bundle = load_review_bundle(report_path)
     selected_entries = [
@@ -56,12 +57,12 @@ def approve_review(
         if entry.occurrence_id in occurrence_ids or entry.group_id in group_ids
     ]
     if not selected_entries:
-        raise ValueError("No matching review entries found")
+        raise CliUserError("No matching review entries found")
 
     if any([title, summary, description]) and len(selected_entries) != 1:
-        raise ValueError("Prose overrides require exactly one selected review entry")
+        raise CliUserError("Prose overrides require exactly one selected review entry")
     if any([title, summary, description]) and group_ids:
-        raise ValueError("Group approval does not support per-entry prose overrides")
+        raise CliUserError("Group approval does not support per-entry prose overrides")
 
     reviewed_at = reviewed_at or _reviewed_at()
     catalog_store = catalog_store or CatalogStore()
@@ -72,16 +73,16 @@ def approve_review(
     for entry in selected_entries:
         if entry.candidate is None:
             if entry.status == "suspected-removed":
-                raise ValueError(
+                raise CliUserError(
                     f"Review entry {entry.occurrence_id} is a suspected removal and "
                     "cannot be approved with approve-review"
                 )
-            raise ValueError(
+            raise CliUserError(
                 f"Review entry {entry.occurrence_id} has no candidate payload and "
                 "cannot be approved with approve-review"
             )
         if entry.source_name != source_name:
-            raise ValueError("Approving multiple source files in one command is not supported")
+            raise CliUserError("Approving multiple source files in one command is not supported")
 
         current = _current_active_record(accepted_records, entry.occurrence_id)
         _validate_review_entry_is_current(entry, current)
@@ -164,15 +165,15 @@ def _validate_review_entry_is_current(
 ) -> None:
     if entry.accepted is None:
         if current is not None:
-            raise ValueError(f"Review entry {entry.occurrence_id} is stale")
+            raise CliUserError(f"Review entry {entry.occurrence_id} is stale")
         return
 
     if current is None:
-        raise ValueError(f"Review entry {entry.occurrence_id} is stale")
+        raise CliUserError(f"Review entry {entry.occurrence_id} is stale")
     accepted_revision = entry.accepted.get("revision")
     accepted_hash = entry.accepted.get("content_hash")
     if current.revision != accepted_revision or current.content_hash != accepted_hash:
-        raise ValueError(f"Review entry {entry.occurrence_id} is stale")
+        raise CliUserError(f"Review entry {entry.occurrence_id} is stale")
 
 
 def _accepted_content_hash(payload: dict[str, object]) -> str:

--- a/src/astrocal/services/review_query_service.py
+++ b/src/astrocal/services/review_query_service.py
@@ -6,6 +6,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
+from ..errors import CliUserError
 from ..jsonio import read_json
 from ..models import (
     AcceptedRecord,
@@ -63,8 +64,28 @@ def list_pending_reviews(
 
 def load_review_bundle(report_path: Path) -> ReviewBundle:
     resolved_path = _resolve_path(report_path)
-    payload = read_json(resolved_path)
-    return ReviewBundle.from_dict(payload)
+    try:
+        payload = read_json(resolved_path)
+    except FileNotFoundError as exc:
+        raise CliUserError(f"Review bundle not found: {resolved_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise CliUserError(f"Review bundle is not valid JSON: {resolved_path}") from exc
+    except (IsADirectoryError, PermissionError) as exc:
+        raise CliUserError(f"Review bundle is not readable: {resolved_path}") from exc
+
+    try:
+        if not isinstance(payload, dict):
+            raise TypeError("top-level JSON value must be an object")
+        return ReviewBundle.from_dict(payload)
+    except KeyError as exc:
+        missing_field = exc.args[0]
+        raise CliUserError(
+            f"Review bundle is malformed: missing {missing_field!r} in {resolved_path}"
+        ) from exc
+    except (TypeError, ValueError) as exc:
+        raise CliUserError(
+            f"Review bundle is malformed: {exc} in {resolved_path}"
+        ) from exc
 
 
 def render_review_bundle(bundle: ReviewBundle, *, output_format: str) -> str:

--- a/src/astrocal/services/stub_service.py
+++ b/src/astrocal/services/stub_service.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 
 from ..adapters import ASTRONOMY_ADAPTERS
+from ..errors import CliUserError
 from ..manifests import load_manifest
 from ..repositories import CatalogStore, ReportStore
 from ..services.build_ics_service import build_calendar
@@ -129,7 +130,7 @@ def show_review_command(args: argparse.Namespace) -> int:
 def approve_review_command(args: argparse.Namespace) -> int:
     description = None
     if args.description_file is not None:
-        description = args.description_file.read_text(encoding="utf-8")
+        description = _read_description_file(args.description_file)
     result = approve_review(
         report_path=args.report,
         reviewer=args.reviewer,
@@ -176,6 +177,19 @@ def _print_validation_reports(reports: list, year: int) -> None:
         print(
             f"validate {report.source_name} status={report.status} year={year}{reason_suffix}"
         )
+
+
+def _read_description_file(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise CliUserError(f"Description file not found: {path}") from exc
+    except IsADirectoryError as exc:
+        raise CliUserError(f"Description file is a directory: {path}") from exc
+    except PermissionError as exc:
+        raise CliUserError(f"Description file is not readable: {path}") from exc
+    except UnicodeDecodeError as exc:
+        raise CliUserError(f"Description file is not valid UTF-8: {path}") from exc
 
 
 @contextmanager

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from astrocal.cli import main
 from astrocal.models import (
     AcceptedRecord,
@@ -61,6 +63,184 @@ class FailingCliAdapter(CliAdapter):
             canary_ok=False,
             source_url="https://example.com/moon-phases",
         )
+
+
+def sample_review_bundle() -> ReviewBundle:
+    return ReviewBundle(
+        calendar_name="astronomy-eclipses",
+        year=2026,
+        generated_at="2026-03-03T00-00-00Z",
+        entries=[
+            ReviewBundleEntry(
+                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                group_id="astronomy/eclipse/2026-08-12/total-sun",
+                status="new",
+                source_name="eclipses",
+                candidate_content_hash="sha256:candidate",
+                generated_content_hash="sha256:candidate",
+                allowed_actions=["approve-as-is", "approve-with-prose-edits"],
+                candidate={
+                    "accepted_revision": None,
+                    "all_day": False,
+                    "body": "sun",
+                    "candidate_status": "new",
+                    "categories": ["Astronomy", "Eclipse"],
+                    "content_hash": "sha256:candidate",
+                    "description": "Generated eclipse description.",
+                    "detail_url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+                    "end": "2026-08-12T19:57:57Z",
+                    "event_type": "eclipse",
+                    "first_seen_at": "2026-03-03T00:00:00Z",
+                    "group_id": "astronomy/eclipse/2026-08-12/total-sun",
+                    "is_default": True,
+                    "last_seen_at": "2026-03-03T00:00:00Z",
+                    "metadata": {
+                        "description_provenance": {
+                            "facts_hash": "sha256:facts",
+                            "facts_schema_version": "eclipse-facts-v1",
+                            "generator": "test-generator",
+                            "generated_at": "2026-03-03T00:00:00Z",
+                            "prompt_version": "eclipse-description-v1",
+                        }
+                    },
+                    "occurrence_id": "astronomy/eclipse/2026-08-12/total-sun/full-duration",
+                    "raw_ref": "data/raw/astronomy/2026/timeanddate-eclipses/eclipse-2.html",
+                    "source_adapter": "timeanddate-eclipse-v1",
+                    "source_type": "astronomy",
+                    "source_validation": {
+                        "checks": ["reachable"],
+                        "detail_url_ok": True,
+                        "reason": None,
+                        "status": "passed",
+                        "validated_at": "2026-03-03T00:00:00Z",
+                    },
+                    "start": "2026-08-12T15:34:15Z",
+                    "summary": "Total Solar Eclipse",
+                    "tags": ["eclipse", "sun", "total"],
+                    "timezone": "UTC",
+                    "timing_source": {
+                        "name": "timeanddate",
+                        "url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
+                    },
+                    "title": "Total Solar Eclipse",
+                    "validation_sources": [],
+                    "variant": "full-duration",
+                },
+                accepted=None,
+            )
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_message"),
+    [
+        (["build", "--calendar", "astronomy-does-not-exist"], "Unknown calendar manifest"),
+        (
+            ["reconcile", "--calendar", "astronomy-does-not-exist", "--year", "2026"],
+            "Unknown calendar manifest",
+        ),
+        (
+            ["run", "--calendar", "astronomy-does-not-exist", "--year", "2026"],
+            "Unknown calendar manifest",
+        ),
+    ],
+)
+def test_commands_report_unknown_calendar_manifest_without_traceback(
+    argv,
+    expected_message,
+    capsys,
+) -> None:
+    exit_code = main(argv)
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_show_review_command_reports_missing_report_without_traceback(capsys, tmp_path) -> None:
+    exit_code = main(["show-review", "--report", str(tmp_path / "missing-review.json")])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Review bundle not found" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_approve_review_command_reports_missing_report_without_traceback(capsys, tmp_path) -> None:
+    exit_code = main(
+        [
+            "approve-review",
+            "--report",
+            str(tmp_path / "missing-review.json"),
+            "--reviewer",
+            "tester",
+            "--occurrence-id",
+            "astronomy/eclipse/2026-08-12/total-sun/full-duration",
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Review bundle not found" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_show_review_command_reports_invalid_json_without_traceback(capsys, tmp_path) -> None:
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text("{not valid json", encoding="utf-8")
+
+    exit_code = main(["show-review", "--report", str(report_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Review bundle is not valid JSON" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_list_pending_reviews_reports_malformed_bundle_without_traceback(capsys, tmp_path) -> None:
+    report_path = tmp_path / "2026-03-03T00-00-00Z" / "review.astronomy-eclipses.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps({"year": 2026, "entries": []}), encoding="utf-8")
+
+    exit_code = main(["list-pending-reviews", "--report-dir", str(tmp_path)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Review bundle is malformed" in captured.err
+    assert "calendar_name" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_approve_review_command_reports_missing_description_file_without_traceback(
+    capsys,
+    tmp_path,
+) -> None:
+    report_path = tmp_path / "review.astronomy-eclipses.json"
+    report_path.write_text(
+        json.dumps(sample_review_bundle().to_dict(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "approve-review",
+            "--report",
+            str(report_path),
+            "--reviewer",
+            "tester",
+            "--occurrence-id",
+            "astronomy/eclipse/2026-08-12/total-sun/full-duration",
+            "--description-file",
+            str(tmp_path / "missing-description.md"),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "Description file not found" in captured.err
+    assert "Traceback" not in captured.err
 
 
 def test_run_command_executes_pipeline(capsys, mocker) -> None:
@@ -521,70 +701,7 @@ def test_show_review_command_supports_markdown_output(capsys, tmp_path) -> None:
 
 
 def test_approve_review_command_writes_accepted_revision(capsys, tmp_path) -> None:
-    bundle = ReviewBundle(
-        calendar_name="astronomy-eclipses",
-        year=2026,
-        generated_at="2026-03-03T00-00-00Z",
-        entries=[
-            ReviewBundleEntry(
-                occurrence_id="astronomy/eclipse/2026-08-12/total-sun/full-duration",
-                group_id="astronomy/eclipse/2026-08-12/total-sun",
-                status="new",
-                source_name="eclipses",
-                candidate_content_hash="sha256:candidate",
-                generated_content_hash="sha256:candidate",
-                allowed_actions=["approve-as-is", "approve-with-prose-edits"],
-                candidate={
-                    "accepted_revision": None,
-                    "all_day": False,
-                    "body": "sun",
-                    "candidate_status": "new",
-                    "categories": ["Astronomy", "Eclipse"],
-                    "content_hash": "sha256:candidate",
-                    "description": "Generated eclipse description.",
-                    "detail_url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
-                    "end": "2026-08-12T19:57:57Z",
-                    "event_type": "eclipse",
-                    "first_seen_at": "2026-03-03T00:00:00Z",
-                    "group_id": "astronomy/eclipse/2026-08-12/total-sun",
-                    "is_default": True,
-                    "last_seen_at": "2026-03-03T00:00:00Z",
-                    "metadata": {
-                        "description_provenance": {
-                            "facts_hash": "sha256:facts",
-                            "facts_schema_version": "eclipse-facts-v1",
-                            "generator": "test-generator",
-                            "generated_at": "2026-03-03T00:00:00Z",
-                            "prompt_version": "eclipse-description-v1",
-                        }
-                    },
-                    "occurrence_id": "astronomy/eclipse/2026-08-12/total-sun/full-duration",
-                    "raw_ref": "data/raw/astronomy/2026/timeanddate-eclipses/eclipse-2.html",
-                    "source_adapter": "timeanddate-eclipse-v1",
-                    "source_type": "astronomy",
-                    "source_validation": {
-                        "checks": ["reachable"],
-                        "detail_url_ok": True,
-                        "reason": None,
-                        "status": "passed",
-                        "validated_at": "2026-03-03T00:00:00Z",
-                    },
-                    "start": "2026-08-12T15:34:15Z",
-                    "summary": "Total Solar Eclipse",
-                    "tags": ["eclipse", "sun", "total"],
-                    "timezone": "UTC",
-                    "timing_source": {
-                        "name": "timeanddate",
-                        "url": "https://www.timeanddate.com/eclipse/solar/2026-august-12",
-                    },
-                    "title": "Total Solar Eclipse",
-                    "validation_sources": [],
-                    "variant": "full-duration",
-                },
-                accepted=None,
-            )
-        ],
-    )
+    bundle = sample_review_bundle()
     report_path = tmp_path / "review.astronomy-eclipses.json"
     report_path.write_text(json.dumps(bundle.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add a dedicated `CliUserError` boundary for expected operator-facing failures
- normalize missing and malformed review bundle errors across the CLI workflow
- add CLI regression coverage for unknown manifests, missing files, and malformed persisted artifacts
- document the CLI error policy and keep the implementation plan in the repo

## Related
Closes #23

## Testing
- `.venv/bin/pytest tests/test_cli.py tests/test_review_approval_service.py tests/test_manifests.py -v`
- `.venv/bin/pytest -v`

## Notes
- expected operator mistakes now return concise `error: ...` output with non-zero exit codes
- unexpected programming failures are still allowed to surface with tracebacks for debugging